### PR TITLE
[trivial] truncate etc/hostname instead rm

### DIFF
--- a/pkg/stages/stages.go
+++ b/pkg/stages/stages.go
@@ -424,7 +424,7 @@ func GetCleanupStage(sis values.System, l types.KairosLogger) []schema.Stage {
 			},
 		},
 		{
-			Name: "truncate /etc/hostname",
+			Name: "truncate hostname",
 			If:   "test -f /etc/hostname",
 			Commands: []string{
 				"truncate -s 0 /etc/hostname",

--- a/pkg/stages/stages.go
+++ b/pkg/stages/stages.go
@@ -2,6 +2,12 @@ package stages
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+
 	semver "github.com/hashicorp/go-version"
 	"github.com/kairos-io/kairos-init/pkg/config"
 	"github.com/kairos-io/kairos-init/pkg/system"
@@ -11,11 +17,6 @@ import (
 	"github.com/mudler/yip/pkg/executor"
 	"github.com/mudler/yip/pkg/schema"
 	"github.com/twpayne/go-vfs/v5"
-	"os"
-	"os/exec"
-	"regexp"
-	"sort"
-	"strings"
 )
 
 func getLatestKernel(l types.KairosLogger) (string, error) {
@@ -423,10 +424,10 @@ func GetCleanupStage(sis values.System, l types.KairosLogger) []schema.Stage {
 			},
 		},
 		{
-			Name: "remove hostname",
+			Name: "truncate /etc/hostname",
 			If:   "test -f /etc/hostname",
 			Commands: []string{
-				"rm /etc/hostname",
+				"truncate -s 0 /etc/hostname",
 			},
 		},
 	}


### PR DESCRIPTION
  
during debug process(not docker build)
 When `docker run ...`
   user might try to run kairo-init directly, like:
`   /kairos-init -l debug -s init --version 1.1.1`
   will fail with msg:
```
   2025-03-20T20:32:28Z INF Done executing stage 'init'
   2025-03-20T20:32:28Z ERR Failed to run the init stage: 1 error occurred:
           * failed to run rm /etc/hostname: exit status 1
   2025-03-20T20:32:28Z ERR 1 error occurred:
           * failed to run rm /etc/hostname: exit status 1
```
   command failed, because docker run handle hostname file:

```
   docker inspect ${running_container_id} |grep -i hostname
           "HostnamePath": "/var/lib/docker/containers/8a5bf3625069bb3277a13fded9f648881ea6742ff5a88215116e8e4aaabf02e3/hostname",
```
   Lets use truncate instead, to eliminate issue


NIT: auto-indent imports