### PR TITLE
Drop imagelabel

### DIFF
--- a/pkg/stages/steps_init.go
+++ b/pkg/stages/steps_init.go
@@ -103,7 +103,6 @@ func GetKairosReleaseStage(sis values.System, log types.KairosLogger) []schema.S
 
 		VERSION_ID and VERSION are the same, needed ?
 		RELEASE is the short version of VERSION and VERSION_ID, the version without the k3s version needed?
-		ARTIFACT is just the IMAGE_LABEL with the OS and OS VERSION in front, useless?
 		GITHUB_REPO is the repo where the image is stored, not really needed?
 		PRETTY_NAME is the same as the ID_LIKE but different? needed?
 
@@ -127,9 +126,6 @@ func GetKairosReleaseStage(sis values.System, log types.KairosLogger) []schema.S
 			log.Debugf("Failed to split the flavor %s", flavor)
 		}
 	}
-	// "24.04-standard-amd64-generic-v3.2.4-36-g24ca209-k3sv1.32.0-k3s1"
-	// We are not doing the k3s software version here
-	imageLabel := fmt.Sprintf("%s-%s-%s-%s-%s", flavorRelease, config.DefaultConfig.Variant, sis.Arch.String(), config.DefaultConfig.Model, config.DefaultConfig.KairosVersion.String())
 
 	env := map[string]string{
 		"KAIROS_ID":                "kairos", // What for?
@@ -147,7 +143,6 @@ func GetKairosReleaseStage(sis values.System, log types.KairosLogger) []schema.S
 		"KAIROS_BUG_REPORT_URL":    "https://github.com/kairos-io/kairos/issues",
 		"KAIROS_HOME_URL":          "https://github.com/kairos-io/kairos",
 		"KAIROS_RELEASE":           config.DefaultConfig.KairosVersion.String(),
-		"KAIROS_IMAGE_LABEL":       imageLabel,                                   // Used by raw image creation...very bad
 		"KAIROS_FRAMEWORK_VERSION": config.DefaultConfig.FrameworkVersion,        // Just for info, could be dropped
 		"KAIROS_FIPS":              fmt.Sprintf("%t", config.DefaultConfig.Fips), // Was the image built with FIPS support?
 	}

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -133,7 +133,6 @@ func (v *Validator) Validate() error {
 		"KAIROS_BUG_REPORT_URL", // Not critical
 		"KAIROS_HOME_URL",       // Not critical
 		"KAIROS_RELEASE",
-		"KAIROS_IMAGE_LABEL",
 	}
 
 	vals, err := godotenv.Read("/etc/kairos-release")


### PR DESCRIPTION
Aurora should use other info to generate the valid artifact image

companion of https://github.com/kairos-io/AuroraBoot/pull/251