### PR TITLE
Bring fix for ssh host keysRemove any host keys generated during build

### DIFF
--- a/pkg/stages/steps_init.go
+++ b/pkg/stages/steps_init.go
@@ -313,6 +313,13 @@ func GetCleanupStage(sis values.System, l types.KairosLogger) []schema.Stage {
 				"truncate -s 0 /etc/hostname",
 			},
 		},
+		{
+			Name: "Remove host ssh keys",
+			If:   "test -d /etc/ssh",
+			Commands: []string{
+				"rm -f /etc/ssh/ssh_host_*_key*",
+			},
+		},
 	}
 
 	var pkgs []values.VersionMap

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kairos-io/kairos-sdk/types"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -186,6 +187,18 @@ func (v *Validator) Validate() error {
 				}
 			}
 		}
+	}
+
+	// Check if there are any ssh host keys in /etc/ssh
+	matches, err := filepath.Glob("/etc/ssh/ssh_host_*_key")
+	if err != nil {
+		multi = multierror.Append(multi, fmt.Errorf("error checking for SSH host keys: %s", err))
+	}
+	if len(matches) > 0 {
+		v.Log.Logger.Warn().Strs("ssh_host_keys", matches).Msg("Found SSH host keys in the system")
+		multi = multierror.Append(multi, fmt.Errorf("found SSH host keys in the system: %v", matches))
+	} else {
+		v.Log.Logger.Info().Msg("No SSH host keys found bundled in the system")
 	}
 
 	return multi.ErrorOrNil()


### PR DESCRIPTION
We ship the images without ssh host keys as they have to be generated in the machine itself

cherry pick from 0.4.6 release


(cherry picked from commit ad0ba07e2fd1ea6c5ebde6710e272a137766ffaa)