### PR TITLE
Forwardport the fix for rhel families

### DIFF
--- a/pkg/stages/steps_init.go
+++ b/pkg/stages/steps_init.go
@@ -366,20 +366,12 @@ func GetCleanupStage(sis values.System, l types.KairosLogger) []schema.Stage {
 func GetServicesStage(_ values.System, _ types.KairosLogger) []schema.Stage {
 	return []schema.Stage{
 		{
-			Name:     "Enable services for Modern systems",
-			OnlyIfOs: "Ubuntu.*|Debian.*|Fedora.*",
-			Systemctl: schema.Systemctl{
-				Enable: []string{
-					"systemd-networkd", // Separate this and use ifOS to trigger it only on systemd systems? i.e. do a reverse regex match somehow
-				},
-			},
-		},
-		{
 			Name:     "Enable services for Debian family",
 			OnlyIfOs: "Ubuntu.*|Debian.*",
 			Systemctl: schema.Systemctl{
 				Enable: []string{
 					"ssh",
+					"systemd-networkd",
 				},
 			},
 		},
@@ -390,11 +382,15 @@ func GetServicesStage(_ values.System, _ types.KairosLogger) []schema.Stage {
 				Enable: []string{
 					"sshd",
 					"systemd-resolved",
+					"systemd-networkd",
 				},
 				Disable: []string{
 					"dnf-makecache",
 					"dnf-makecache.timer",
 				},
+			},
+			Commands: []string{
+				"systemctl unmask getty.target", // Unmask getty.target to allow login on ttys as it comes masked by default
 			},
 		},
 		{

--- a/pkg/stages/steps_install.go
+++ b/pkg/stages/steps_install.go
@@ -69,7 +69,16 @@ func GetInstallStage(sis values.System, logger types.KairosLogger) ([]schema.Sta
 	}
 
 	// TODO(rhel): Add zfs packages? Currently we add the repos to alma+rocky but we don't install the packages so?
-	return []schema.Stage{
+	stage := []schema.Stage{
+		{
+			Name:     "Install epel-release",
+			OnlyIfOs: "CentOS.*|RedHat.*|Rocky.*|AlmaLinux.*",
+			Packages: schema.Packages{
+				Install: []string{
+					"epel-release",
+				},
+			},
+		},
 		{
 			Name: "Install base packages",
 			Packages: schema.Packages{
@@ -78,7 +87,8 @@ func GetInstallStage(sis values.System, logger types.KairosLogger) ([]schema.Sta
 				Upgrade: true,
 			},
 		},
-	}, nil
+	}
+	return stage, nil
 }
 
 // GetInstallFrameworkStage This returns the Stage to install the framework image

--- a/pkg/values/packagemaps.go
+++ b/pkg/values/packagemaps.go
@@ -397,6 +397,7 @@ var BasePackages = PackageMap{
 				"qemu-guest-agent",
 				"systemd", // Basic tool.
 				"systemd-resolved",
+				"systemd-networkd",
 				"which",      // Basic tool. Basepackages?
 				"cryptsetup", // For encrypted partitions support, needed for trusted boot and dracut building
 			},


### PR DESCRIPTION
Comes from 0.4.7 branch.
install epel repo
install systemd-networkd
enable proper services
unmask getty.target so we get loging prompts