### PR TITLE
Drop variant flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -137,9 +137,9 @@ func init() {
 	rootCmd.Flags().StringVarP(&config.DefaultConfig.Registry, "registry", "r", "", "registry and org where the image is gonna be pushed (e.g. quay.io/kairos). This is mainly used on upgrades to search for available images to upgrade to")
 	rootCmd.Flags().StringVarP(&trusted, "trusted", "t", "false", "init the system for Trusted Boot, changes bootloader to systemd")
 	rootCmd.Flags().BoolVar(&validate, "validate", false, "validate the running os to see if it all the pieces are in place")
-	rootCmd.Flags().BoolVar(&config.DefaultConfig.Fips, "fips", false, "use fips framework. For FIPS 140-2 compliance images")
+	rootCmd.Flags().BoolVar(&config.DefaultConfig.Fips, "fips", false, "use fips kairos binary versions. For FIPS 140-2 compliance images")
 	rootCmd.Flags().StringVarP(&version, "version", "v", "", "set a version number to use for the generated system. Its used to identify this system for upgrades and such. Required.")
-	rootCmd.Flags().BoolVar(&config.DefaultConfig.Extensions, "stage-extensions", false, "enable stage extensions mode")
+	rootCmd.Flags().BoolVarP(&config.DefaultConfig.Extensions, "stage-extensions", "x", false, "enable stage extensions mode")
 
 	// Mark required flags
 	rootCmd.MarkFlagRequired("version")


### PR DESCRIPTION
We dont need to have a variant flag, it wil be set automatically based
on the k8s provider.

If the value is empty, which is the default now, it will be a core image
as usual.

If any valid provider is set, then it will generate a standard image.

But we no longer need to set that flag manually thanks to cobra and its
proper defaults and such

Fixes https://github.com/kairos-io/kairos-init/issues/51

Signed-off-by: Itxaka <itxaka@kairos.io>