### PR TITLE
Drop kube-vip binary

### DIFF
--- a/pkg/bundled/bundled.go
+++ b/pkg/bundled/bundled.go
@@ -31,9 +31,6 @@ var EmbeddedKairosProviderFips []byte
 //go:embed binaries/edgevpn
 var EmbeddedEdgeVPN []byte
 
-//go:embed binaries/kube-vip
-var EmbeddedKubeVIP []byte
-
 // EmbeddedConfigs contains the cloudconfigs that go into /system/oem
 //
 //go:embed cloudconfigs/*

--- a/pkg/stages/steps_install.go
+++ b/pkg/stages/steps_install.go
@@ -132,12 +132,6 @@ func GetInstallProviderAndKubernetes(sis values.System, l types.KairosLogger) []
 		return data
 	}
 
-	err = os.WriteFile("/usr/bin/kube-vip", bundled.EmbeddedKubeVIP, 0755)
-	if err != nil {
-		l.Logger.Error().Err(err).Msg("Failed to write edgevpn")
-		return data
-	}
-
 	switch config.DefaultConfig.KubernetesProvider {
 	case config.K3sProvider:
 		cmd := "INSTALL_K3S_BIN_DIR=/usr/bin INSTALL_K3S_SKIP_ENABLE=true INSTALL_K3S_SKIP_SELINUX_RPM=true"

--- a/renovate.json
+++ b/renovate.json
@@ -77,18 +77,6 @@
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
       "packageNameTemplate": "mudler/edgevpn"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": [
-        "^Makefile$"
-      ],
-      "matchStrings": [
-        "KUBE_VIP_VERSION\\s*:=\\s*(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
-      ],
-      "datasourceTemplate": "github-releases",
-      "versioningTemplate": "semver",
-      "packageNameTemplate": "kube-vip/kube-vip"
     }
   ]
 }


### PR DESCRIPTION
No longer necessary as the provider now uses the kubevips libraries directly