### PR TITLE
Only output dracut verbose if in debug

### DIFF
--- a/pkg/stages/steps_init.go
+++ b/pkg/stages/steps_init.go
@@ -121,13 +121,18 @@ func GetInitrdStage(sys values.System, logger types.KairosLogger) ([]schema.Stag
 			}...)
 		}
 
+		dracutCmd := fmt.Sprintf("dracut -f /boot/initrd %s", kernel)
+		if config.DefaultConfig.Level == "debug" {
+			dracutCmd = fmt.Sprintf("dracut -v -f /boot/initrd %s", kernel)
+		}
+
 		stage = append(stage, []schema.Stage{
 			{
 				Name:     "Create new initrd",
 				OnlyIfOs: "Ubuntu.*|Debian.*|Fedora.*|CentOS.*|RedHat.*|Rocky.*|AlmaLinux.*|SLES.*|[O-o]penSUSE.*",
 				Commands: []string{
 					fmt.Sprintf("depmod -a %s", kernel),
-					fmt.Sprintf("dracut -v -f /boot/initrd %s", kernel),
+					dracutCmd,
 				},
 			},
 			{


### PR DESCRIPTION
Otherwise the logs get full of the dracut stuff and we want to be able to see other things, especially unde non debug levels