### PR TITLE
Allow overrides per binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM golang AS build
 ARG TARGETARCH
 WORKDIR /app
-COPY go.mod go.sum .
-RUN go mod download
-COPY . .
+# Copy the Makefile first to leverage Docker cache
+COPY Makefile .
 RUN apt-get update && apt-get install -y --no-install-recommends xz-utils file && \
   curl -Ls https://github.com/upx/upx/releases/download/v5.0.0/upx-5.0.0-${TARGETARCH}_linux.tar.xz -o - | tar xvJf - -C /tmp && \
   cp /tmp/upx-5.0.0-${TARGETARCH}_linux/upx /usr/local/bin/ && \
@@ -11,6 +10,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends xz-utils file &
   apt-get remove -y xz-utils && \
   rm -rf /var/lib/apt/lists/*
 RUN make all
+# Now copy the go.mod and go.sum files to leverage Docker cache
+COPY go.mod go.sum .
+RUN go mod download
+# Copy the rest of the source code
+COPY . .
 ENV CGO_ENABLED=0
 RUN echo "Building version: $(git describe --tags --always --dirty)}"
 RUN echo "Building commit: $(git rev-parse --short HEAD)"

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -4,9 +4,7 @@ ARG VALIDATE_IMAGE=ubuntu:24.04
 FROM golang AS build
 ARG TARGETARCH
 WORKDIR /app
-COPY go.mod go.sum .
-RUN go mod download
-COPY . .
+COPY Makefile .
 RUN apt-get update && apt-get install -y --no-install-recommends xz-utils file && \
   curl -Ls https://github.com/upx/upx/releases/download/v5.0.0/upx-5.0.0-${TARGETARCH}_linux.tar.xz -o - | tar xvJf - -C /tmp && \
   cp /tmp/upx-5.0.0-${TARGETARCH}_linux/upx /usr/local/bin/ && \
@@ -14,6 +12,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends xz-utils file &
   apt-get remove -y xz-utils && \
   rm -rf /var/lib/apt/lists/*
 RUN make all
+COPY go.mod go.sum .
+RUN go mod download
+COPY . .
 ENV CGO_ENABLED=0
 RUN go build -o /app/kairos-init .
 

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,28 @@
 # Variables
 AGENT_VERSION := v2.20.4
 IMMUCORE_VERSION := v0.10.0
-KCRYPT_CHALLENGER_VERSION := v0.11.2
-AGENT_PROVIDER_VERSION := v2.12.0
+KCRYPT_DISCOVERY_CHALLENGER_VERSION := v0.11.2
+PROVIDER_KAIROS_VERSION := v2.13.1
 EDGEVPN_VERSION := v0.30.2
 ARCH := $(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
-BINARY_NAMES := kairos-agent immucore kcrypt-discovery-challenger kairos-cli
+BINARY_NAMES := kairos-agent immucore kcrypt-discovery-challenger provider-kairos
 OUTPUT_DIR := pkg/bundled/binaries
 OUTPUT_DIR_FIPS := pkg/bundled/binaries/fips
 
 # URLs for binaries
 define URL_TEMPLATE
-https://github.com/kairos-io/$1/releases/download/$2/$3-$2-Linux-$(ARCH)$4.tar.gz
+https://github.com/kairos-io/$1/releases/download/$2/$1-$2-Linux-$(ARCH)$3.tar.gz
 endef
 
-kairos-agent_URL := $(call URL_TEMPLATE,kairos-agent,$(AGENT_VERSION),kairos-agent)
-immucore_URL := $(call URL_TEMPLATE,immucore,$(IMMUCORE_VERSION),immucore)
-kcrypt-discovery-challenger_URL := $(call URL_TEMPLATE,kcrypt-challenger,$(KCRYPT_CHALLENGER_VERSION),kcrypt-discovery-challenger)
-kairos-cli_URL := $(call URL_TEMPLATE,provider-kairos,$(AGENT_PROVIDER_VERSION),kairos-cli)
+kairos-agent_URL := $(call URL_TEMPLATE,kairos-agent,$(AGENT_VERSION))
+immucore_URL := $(call URL_TEMPLATE,immucore,$(IMMUCORE_VERSION))
+kcrypt-discovery-challenger_URL := $(call URL_TEMPLATE,kcrypt-discovery-challenger,$(KCRYPT_DISCOVERY_CHALLENGER_VERSION))
+provider-kairos_URL := $(call URL_TEMPLATE,provider-kairos,$(PROVIDER_KAIROS_VERSION))
 
-kairos-agent-fips_URL := $(call URL_TEMPLATE,kairos-agent,$(AGENT_VERSION),kairos-agent,-fips)
-immucore-fips_URL := $(call URL_TEMPLATE,immucore,$(IMMUCORE_VERSION),immucore,-fips)
-kcrypt-discovery-challenger-fips_URL := $(call URL_TEMPLATE,kcrypt-challenger,$(KCRYPT_CHALLENGER_VERSION),kcrypt-discovery-challenger,-fips)
-kairos-cli-fips_URL := $(call URL_TEMPLATE,provider-kairos,$(AGENT_PROVIDER_VERSION),kairos-cli,-fips)
+kairos-agent-fips_URL := $(call URL_TEMPLATE,kairos-agent,$(AGENT_VERSION),-fips)
+immucore-fips_URL := $(call URL_TEMPLATE,immucore,$(IMMUCORE_VERSION),-fips)
+kcrypt-discovery-challenger-fips_URL := $(call URL_TEMPLATE,kcrypt-discovery-challenger,$(KCRYPT_DISCOVERY_CHALLENGER_VERSION),-fips)
+provider-kairos-fips_URL := $(call URL_TEMPLATE,provider-kairos,$(PROVIDER_KAIROS_VERSION),-fips)
 
 .PHONY: all prepare download compress cleanup
 

--- a/main.go
+++ b/main.go
@@ -85,7 +85,6 @@ var rootCmd = &cobra.Command{
 		}
 
 		config.DefaultConfig.KairosVersion = *sv
-		litter.Config.HideZeroValues = true
 		litter.Config.HidePrivateFields = false
 		logger.Debug(litter.Sdump(config.DefaultConfig))
 

--- a/pkg/bundled/bundled.go
+++ b/pkg/bundled/bundled.go
@@ -22,10 +22,10 @@ var EmbeddedKcryptChallenger []byte
 //go:embed binaries/fips/kcrypt-discovery-challenger
 var EmbeddedKcryptChallengerFips []byte
 
-//go:embed binaries/kairos-cli
+//go:embed binaries/provider-kairos
 var EmbeddedKairosProvider []byte
 
-//go:embed binaries/fips/kairos-cli
+//go:embed binaries/fips/provider-kairos
 var EmbeddedKairosProviderFips []byte
 
 //go:embed binaries/edgevpn

--- a/pkg/stages/stages.go
+++ b/pkg/stages/stages.go
@@ -80,8 +80,8 @@ func RunInstallStage(logger types.KairosLogger) (schema.YipConfig, error) {
 	data.Stages["install"] = append(data.Stages["install"], GetInstallGrubBootArgsStage(sis, logger)...)
 	// Add the services
 	data.Stages["install"] = append(data.Stages["install"], GetInstallServicesStage(sis, logger)...)
-	// Add the provider and kubernetes
-	data.Stages["install"] = append(data.Stages["install"], GetInstallProviderAndKubernetes(sis, logger)...)
+	// Add kubernetes
+	data.Stages["install"] = append(data.Stages["install"], GetInstallKubernetesStage(sis, logger)...)
 	// Add the miscellaneous files
 	miscellaneous, err := InstallKairosMiscellaneousFilesStage(sis, logger)
 	if err != nil {
@@ -115,6 +115,12 @@ func RunInstallStage(logger types.KairosLogger) (schema.YipConfig, error) {
 
 	// Bring kairos binaries
 	err = GetInstallKairosBinaries(sis, logger)
+	if err != nil {
+		return schema.YipConfig{}, err
+	}
+
+	// Bring provider binaries
+	err = GetInstallProviderBinaries(sis, logger)
 	if err != nil {
 		return schema.YipConfig{}, err
 	}

--- a/renovate.json
+++ b/renovate.json
@@ -48,11 +48,11 @@
         "/^Makefile$/"
       ],
       "matchStrings": [
-        "KCRYPT_CHALLENGER_VERSION\\s*:=\\s*(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
+        "KCRYPT_DISCOVERY_CHALLENGER_VERSION\\s*:=\\s*(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
       ],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
-      "packageNameTemplate": "kairos-io/kcrypt-challenger"
+      "packageNameTemplate": "kairos-io/kcrypt-discovery-challenger"
     },
     {
       "customType": "regex",
@@ -60,7 +60,7 @@
         "/^Makefile$/"
       ],
       "matchStrings": [
-        "AGENT_PROVIDER_VERSION\\s*:=\\s*(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
+        "PROVIDER_KAIROS_VERSION\\s*:=\\s*(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
       ],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",


### PR DESCRIPTION
This allows loading overrides for the binaries so during runtime you can manipulate those.

Useful for testing new versions without having to wait for init to be updated and released to bundle new versions. Bundled versions are still there and they are the default.

Also reworks a bit the dockerfile to take advantage of docker cache on rebuilds.

Reworks a bit the Makefile for the renaming of upstream releases and repos so all its more standard now