### PR TITLE
Introduce flags to skip installs

### DIFF
--- a/main.go
+++ b/main.go
@@ -139,10 +139,12 @@ func init() {
 	rootCmd.Flags().BoolVar(&config.DefaultConfig.Fips, "fips", false, "use fips kairos binary versions. For FIPS 140-2 compliance images")
 	rootCmd.Flags().StringVarP(&version, "version", "v", "", "set a version number to use for the generated system. Its used to identify this system for upgrades and such. Required.")
 	rootCmd.Flags().BoolVarP(&config.DefaultConfig.Extensions, "stage-extensions", "x", false, "enable stage extensions mode")
+	rootCmd.Flags().BoolVar(&config.DefaultConfig.SkipInstallPackages, "skip-packages-install", false, "Skip the install of packages. This assumes that the needed packages are already installed in the base image.")
+	rootCmd.Flags().BoolVar(&config.DefaultConfig.SkipInstallK8s, "skip-k8s-install", false, "Skip the install of k8s packages. This assumes that the needed packages are already installed in the base image.")
 
 	// Mark required flags
-	rootCmd.MarkFlagRequired("version")
-	rootCmd.MarkFlagRequired("registry")
+	_ = rootCmd.MarkFlagRequired("version")
+	_ = rootCmd.MarkFlagRequired("registry")
 
 	rootCmd.AddCommand(validateCmd)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,18 +10,20 @@ import (
 // Config is the struct to track the config of the init image
 // So we can access it from anywhere
 type Config struct {
-	Level              string
-	Stage              string
-	Model              string
-	Variant            Variant
-	Registry           string
-	TrustedBoot        bool
-	Fips               bool
-	KubernetesProvider KubernetesProvider
-	KubernetesVersion  string
-	KairosVersion      semver.Version
-	Extensions         bool
-	VersionOverrides   VersionOverrides
+	Level               string
+	Stage               string
+	Model               string
+	Variant             Variant
+	Registry            string
+	TrustedBoot         bool
+	Fips                bool
+	KubernetesProvider  KubernetesProvider
+	KubernetesVersion   string
+	KairosVersion       semver.Version
+	Extensions          bool
+	VersionOverrides    VersionOverrides
+	SkipInstallPackages bool
+	SkipInstallK8s      bool
 }
 
 // VersionOverrides holds version overrides for binaries

--- a/pkg/stages/steps_install.go
+++ b/pkg/stages/steps_install.go
@@ -22,6 +22,10 @@ import (
 // This file contains the stages for the install process
 
 func GetInstallStage(sis values.System, logger types.KairosLogger) ([]schema.Stage, error) {
+	if config.DefaultConfig.SkipInstallPackages {
+		logger.Logger.Warn().Msg("Skipping install packages stage")
+		return []schema.Stage{}, nil
+	}
 	// Fips + ubuntu fails early and redirect to our Example
 	if sis.Distro == values.Ubuntu && config.DefaultConfig.Fips {
 		return nil, fmt.Errorf("FIPS is not supported on Ubuntu without a PRO account and extra packages.\n" +
@@ -100,7 +104,11 @@ func GetInstallStage(sis values.System, logger types.KairosLogger) ([]schema.Sta
 }
 
 // GetInstallKubernetesStage returns the the kubernetes install stage
-func GetInstallKubernetesStage(sis values.System, l types.KairosLogger) []schema.Stage {
+func GetInstallKubernetesStage(sis values.System, logger types.KairosLogger) []schema.Stage {
+	if config.DefaultConfig.SkipInstallK8s {
+		logger.Logger.Warn().Msg("Skipping installing kubernetes stage")
+		return []schema.Stage{}
+	}
 	var stages []schema.Stage
 
 	// If its core we dont do anything here


### PR DESCRIPTION
Adds 2 new options flags:

 - skip-packages-install which will skip the install of packages from the package manager. Useful when iterating over the same base image when the base image already has the required packages on it
 - skip-k8s-install which will skip installing the k8s provider. Useful when more control is wanted over how and what they install, maybe the provider or edgevpn is wanted but not a full k3s/k0s install which blows the image. This allows to have the provider+edgevpn in the base image and put the k8s provider in a sysext for example, so they are not part of the base image