### PR TITLE
Fixes building RHEL images

### DIFF
--- a/pkg/stages/stages.go
+++ b/pkg/stages/stages.go
@@ -43,7 +43,7 @@ func RunAllStages(logger types.KairosLogger) (schema.YipConfig, error) {
 // This is good if we are doing the init in layers as this will allow us to run the install stage and cache that then run
 // the init stage later so we can cache the install stage which is usually the longest
 func RunInstallStage(logger types.KairosLogger) (schema.YipConfig, error) {
-	if config.ContainsSkipStep("install") {
+	if config.ContainsSkipStep(values.InstallStage) {
 		logger.Logger.Warn().Msg("Skipping install stage as per configuration")
 		return schema.YipConfig{Stages: map[string][]schema.Stage{}}, nil
 	}
@@ -136,7 +136,7 @@ func RunInstallStage(logger types.KairosLogger) (schema.YipConfig, error) {
 // This is good if we are doing the init in layers as this will allow us to run the install stage and cache that then run
 // the init stage later so we can cache the install stage which is usually the longest
 func RunInitStage(logger types.KairosLogger) (schema.YipConfig, error) {
-	if config.ContainsSkipStep("init") {
+	if config.ContainsSkipStep(values.InitStage) {
 		logger.Logger.Warn().Msg("Skipping init stage as per configuration")
 		return schema.YipConfig{Stages: map[string][]schema.Stage{}}, nil
 	}

--- a/pkg/stages/steps_init.go
+++ b/pkg/stages/steps_init.go
@@ -24,7 +24,7 @@ import (
 // signed during the build process
 // If we have fips, we need to add the fips support to the initrd as well
 func GetInitrdStage(sys values.System, logger types.KairosLogger) ([]schema.Stage, error) {
-	if config.ContainsSkipStep("initrd") {
+	if config.ContainsSkipStep(values.InitrdStep) {
 		logger.Logger.Warn().Msg("Skipping initrd generation stage")
 		return []schema.Stage{}, nil
 	}
@@ -81,7 +81,7 @@ func GetInitrdStage(sys values.System, logger types.KairosLogger) ([]schema.Stag
 // For example, for upgrading the version its taken from here
 // During boot, grub checks this file to know things about the system and enable or disable stuff, like console for rpi images
 func GetKairosReleaseStage(sis values.System, log types.KairosLogger) []schema.Stage {
-	if config.ContainsSkipStep("kairosRelease") {
+	if config.ContainsSkipStep(values.KairosReleaseStep) {
 		log.Logger.Warn().Msg("Skipping /etc/kairos-release generation stage")
 		return []schema.Stage{}
 	}
@@ -201,7 +201,7 @@ func GetKairosReleaseStage(sis values.System, log types.KairosLogger) []schema.S
 // and then clean it up so http uki boot works out of the box. By default the nvdimm modules needed are in that package
 // We could just install the package but its a 100+MB  package and we need just 4 or 5 modules.
 func GetWorkaroundsStage(sis values.System, l types.KairosLogger) []schema.Stage {
-	if config.ContainsSkipStep("workarounds") {
+	if config.ContainsSkipStep(values.WorkaroundsStep) {
 		l.Logger.Warn().Msg("Skipping workarounds stage")
 		return []schema.Stage{}
 	}
@@ -261,7 +261,7 @@ func GetWorkaroundsStage(sis values.System, l types.KairosLogger) []schema.Stage
 // we have build the initramfs we dont need them anymore
 // TODO: Remove package cache for all distros
 func GetCleanupStage(sis values.System, l types.KairosLogger) []schema.Stage {
-	if config.ContainsSkipStep("cleanup") {
+	if config.ContainsSkipStep(values.CleanupStep) {
 		l.Logger.Warn().Msg("Skipping cleanup stage")
 		return []schema.Stage{}
 	}
@@ -359,7 +359,7 @@ func GetCleanupStage(sis values.System, l types.KairosLogger) []schema.Stage {
 // GetServicesStage Returns the services stage
 // This stage is about configuring the services to be run on the system. Either enabling or disabling them.
 func GetServicesStage(_ values.System, l types.KairosLogger) []schema.Stage {
-	if config.ContainsSkipStep("services") {
+	if config.ContainsSkipStep(values.ServicesStep) {
 		l.Logger.Warn().Msg("Skipping services stage")
 		return []schema.Stage{}
 	}
@@ -437,7 +437,7 @@ func GetServicesStage(_ values.System, l types.KairosLogger) []schema.Stage {
 // This stage also cleans up the old kernels and initrd files that are no longer needed.
 // This is a bit of a complex one, as every distro has its own way of doing things but we make it work here
 func GetKernelStage(_ values.System, logger types.KairosLogger) ([]schema.Stage, error) {
-	if config.ContainsSkipStep("kernel") {
+	if config.ContainsSkipStep(values.KernelStep) {
 		logger.Logger.Warn().Msg("Skipping kernel stage")
 		return []schema.Stage{}, nil
 	}

--- a/pkg/stages/steps_init.go
+++ b/pkg/stages/steps_init.go
@@ -392,7 +392,7 @@ func GetServicesStage(_ values.System, l types.KairosLogger) []schema.Stage {
 		},
 		{
 			Name:                 "Enable services for RHEL family",
-			OnlyIfOs:             "Fedora.*|CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*",
+			OnlyIfOs:             "Fedora.*|CentOS.*|Rocky.*|AlmaLinux.*",
 			OnlyIfServiceManager: "systemd",
 			Systemctl: schema.Systemctl{
 				Enable: []string{

--- a/pkg/stages/steps_install.go
+++ b/pkg/stages/steps_install.go
@@ -86,7 +86,7 @@ func GetInstallStage(sis values.System, logger types.KairosLogger) ([]schema.Sta
 	stage := []schema.Stage{
 		{
 			Name:     "Install epel-release",
-			OnlyIfOs: "CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*",
+			OnlyIfOs: "CentOS.*|Rocky.*|AlmaLinux.*",
 			Packages: schema.Packages{
 				Install: []string{
 					"epel-release",
@@ -622,6 +622,11 @@ func GetKairosInitramfsFilesStage(sis values.System, l types.KairosLogger) ([]sc
 					networkModule = "network"
 				}
 			}
+		}
+
+		if sis.Distro == values.RedHat {
+			// On redhat we drop the systemd-networkd module as there is no systemd-networkd on rh9
+			networkModule = "network-legacy"
 		}
 
 		if sis.Distro == values.Fedora {

--- a/pkg/stages/steps_install.go
+++ b/pkg/stages/steps_install.go
@@ -24,7 +24,7 @@ import (
 // This file contains the stages for the install process
 
 func GetInstallStage(sis values.System, logger types.KairosLogger) ([]schema.Stage, error) {
-	if config.ContainsSkipStep("installPackages") {
+	if config.ContainsSkipStep(values.InstallPackagesStep) {
 		logger.Logger.Warn().Msg("Skipping install packages stage")
 		return []schema.Stage{}, nil
 	}
@@ -107,7 +107,7 @@ func GetInstallStage(sis values.System, logger types.KairosLogger) ([]schema.Sta
 
 // GetInstallKubernetesStage returns the the kubernetes install stage
 func GetInstallKubernetesStage(sis values.System, logger types.KairosLogger) []schema.Stage {
-	if config.ContainsSkipStep("kubernetes") {
+	if config.ContainsSkipStep(values.KubernetesStep) {
 		logger.Logger.Warn().Msg("Skipping installing kubernetes stage")
 		return []schema.Stage{}
 	}
@@ -210,7 +210,7 @@ func GetInstallKubernetesStage(sis values.System, logger types.KairosLogger) []s
 // TODO: Make them first class yip files in code and just dump them into the system?
 // That way they can be set as a normal yip stage maybe? a yip stage that dumps the yip stage lol
 func GetInstallOemCloudConfigs(l types.KairosLogger) error {
-	if config.ContainsSkipStep("cloudconfigs") {
+	if config.ContainsSkipStep(values.CloudconfigsStep) {
 		l.Logger.Warn().Msg("Skipping installing cloudconfigs stage")
 		return nil
 	}
@@ -254,7 +254,7 @@ func GetInstallOemCloudConfigs(l types.KairosLogger) error {
 // This stage takes care of creating the default branding files that are used by the system
 // Thinks like interactive install or recoivery welcome text or grubmenu configs
 func GetInstallBrandingStage(_ values.System, l types.KairosLogger) []schema.Stage {
-	if config.ContainsSkipStep("branding") {
+	if config.ContainsSkipStep(values.BrandingStep) {
 		l.Logger.Warn().Msg("Skipping installing branding stage")
 		return []schema.Stage{}
 	}
@@ -308,7 +308,7 @@ func GetInstallBrandingStage(_ values.System, l types.KairosLogger) []schema.Sta
 // GetInstallGrubBootArgsStage returns the stage to write the grub configs
 // This stage takes create of creating the /etc/cos/bootargs.cfg and /etc/cos/grub.cfg
 func GetInstallGrubBootArgsStage(_ values.System, l types.KairosLogger) []schema.Stage {
-	if config.ContainsSkipStep("grub") {
+	if config.ContainsSkipStep(values.GrubStep) {
 		l.Logger.Warn().Msg("Skipping installing grub stage")
 		return []schema.Stage{}
 	}
@@ -345,7 +345,7 @@ func GetInstallGrubBootArgsStage(_ values.System, l types.KairosLogger) []schema
 
 // GetInstallKairosBinaries directly installs the kairos binaries from bundled binaries
 func GetInstallKairosBinaries(sis values.System, l types.KairosLogger) error {
-	if config.ContainsSkipStep("kairosBinaries") {
+	if config.ContainsSkipStep(values.KairosBinariesStep) {
 		l.Logger.Warn().Msg("Skipping installing Kairos binaries stage")
 		return nil
 	}
@@ -414,7 +414,7 @@ func GetInstallKairosBinaries(sis values.System, l types.KairosLogger) error {
 
 // GetInstallProviderBinaries installs the provider and edgevpn binaries
 func GetInstallProviderBinaries(sis values.System, l types.KairosLogger) error {
-	if config.ContainsSkipStep("providerBinaries") {
+	if config.ContainsSkipStep(values.ProviderBinariesStep) {
 		l.Logger.Warn().Msg("Skipping installing Kairos k8s provider binaries stage")
 		return nil
 	}
@@ -514,7 +514,7 @@ func GetInstallProviderBinaries(sis values.System, l types.KairosLogger) error {
 // GetKairosInitramfsFilesStage installs the kairos initramfs files
 // This stage is used to install the initramfs files that are needed for the system to boot
 func GetKairosInitramfsFilesStage(sis values.System, l types.KairosLogger) ([]schema.Stage, error) {
-	if config.ContainsSkipStep("initramfsConfigs") {
+	if config.ContainsSkipStep(values.InitramfsConfigsStep) {
 		l.Logger.Warn().Msg("Skipping installing initramfs configs stage")
 		return []schema.Stage{}, nil
 	}
@@ -745,7 +745,7 @@ func GetKairosInitramfsFilesStage(sis values.System, l types.KairosLogger) ([]sc
 // GetKairosMiscellaneousFilesStage installs the kairos miscellaneous files
 // Like small scripts or other files that are not part of the main install process
 func GetKairosMiscellaneousFilesStage(sis values.System, l types.KairosLogger) []schema.Stage {
-	if config.ContainsSkipStep("miscellaneous") {
+	if config.ContainsSkipStep(values.MiscellaneousStep) {
 		l.Logger.Warn().Msg("Skipping installing miscellaneous configs stage")
 		return []schema.Stage{}
 	}

--- a/pkg/values/packagemaps.go
+++ b/pkg/values/packagemaps.go
@@ -409,10 +409,23 @@ var BasePackages = PackageMap{
 				"qemu-guest-agent",
 				"systemd", // Basic tool.
 				"systemd-resolved",
-				"systemd-networkd",
 				"which",      // Basic tool. Basepackages?
 				"cryptsetup", // For encrypted partitions support, needed for trusted boot and dracut building
 				"tpm2-tss",   // For TPM support, mainly trusted boot
+			},
+		},
+	},
+	RockyLinux: {
+		ArchCommon: {
+			Common: {
+				"systemd-networkd",
+			},
+		},
+	},
+	AlmaLinux: {
+		ArchCommon: {
+			Common: {
+				"systemd-networkd",
 			},
 		},
 	},

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -90,26 +90,46 @@ type StepInfo struct {
 	Value string
 }
 
+const (
+	InitStage            = "init"             // Full init stage
+	InstallStage         = "install"          // Full install stage
+	InstallPackagesStep  = "installPackages"  // Installs the base system packages
+	InitrdStep           = "initrd"           // Generates the initrd
+	KairosReleaseStep    = "kairosRelease"    // Creates and fills the /etc/kairos-release file
+	WorkaroundsStep      = "workarounds"      // Applies workarounds for known issues
+	CleanupStep          = "cleanup"          // Cleans up the system of unneeded packages and files
+	ServicesStep         = "services"         // Creates and enables required services
+	KernelStep           = "kernel"           // Installs the kernel
+	KubernetesStep       = "kubernetes"       // Installs the kubernetes provider
+	CloudconfigsStep     = "cloudconfigs"     // Installs the cloud-configs for the system
+	BrandingStep         = "branding"         // Applies the branding for the system
+	GrubStep             = "grub"             // Configures the grub bootloader
+	KairosBinariesStep   = "kairosBinaries"   // Installs the kairos binaries
+	ProviderBinariesStep = "providerBinaries" // Installs the kairos provider binaries for k8s
+	InitramfsConfigsStep = "initramfsConfigs" // Configures the initramfs for the system
+	MiscellaneousStep    = "miscellaneous"    // Applies miscellaneous configurations
+)
+
 // StepsInfo returns a slice of StepInfo containing the steps and their descriptions
 func StepsInfo() []StepInfo {
 	steps := map[string]string{
-		"init":             "The full init stage, which includes kairosRelease, kubernetes, initrd, services, workarounds and cleanup steps",
-		"install":          "The full install stage, which includes installPackages, kubernetes, cloudconfigs, branding, grub, services, kairosBinaries, providerBinaries, initramfsConfigs and miscellaneous steps",
-		"installPackages":  "installs the base system packages",
-		"initrd":           "generates the initrd",
-		"kairosRelease":    "creates and fills the /etc/kairos-release file",
-		"workarounds":      "applies workarounds for known issues",
-		"cleanup":          "cleans up the system of unneeded packages and files",
-		"services":         "creates and enables required services",
-		"kernel":           "installs the kernel",
-		"kubernetes":       "installs the kubernetes provider",
-		"cloudconfigs":     "installs the cloud-configs for the system",
-		"branding":         "applies the branding for the system",
-		"grub":             "configures the grub bootloader",
-		"kairosBinaries":   "installs the kairos binaries",
-		"providerBinaries": "installs the kairos provider binaries for k8s",
-		"initramfsConfigs": "configures the initramfs for the system",
-		"miscellaneous":    "applies miscellaneous configurations",
+		InitStage:            "The full init stage, which includes kairosRelease, kubernetes, initrd, services, workarounds and cleanup steps",
+		InstallStage:         "The full install stage, which includes installPackages, kubernetes, cloudconfigs, branding, grub, services, kairosBinaries, providerBinaries, initramfsConfigs and miscellaneous steps",
+		InstallPackagesStep:  "installs the base system packages",
+		InitrdStep:           "generates the initrd",
+		KairosReleaseStep:    "creates and fills the /etc/kairos-release file",
+		WorkaroundsStep:      "applies workarounds for known issues",
+		CleanupStep:          "cleans up the system of unneeded packages and files",
+		ServicesStep:         "creates and enables required services",
+		KernelStep:           "installs the kernel",
+		KubernetesStep:       "installs the kubernetes provider",
+		CloudconfigsStep:     "installs the cloud-configs for the system",
+		BrandingStep:         "applies the branding for the system",
+		GrubStep:             "configures the grub bootloader",
+		KairosBinariesStep:   "installs the kairos binaries",
+		ProviderBinariesStep: "installs the kairos provider binaries for k8s",
+		InitramfsConfigsStep: "configures the initramfs for the system",
+		MiscellaneousStep:    "applies miscellaneous configurations",
 	}
 	keys := make([]string, 0, len(steps))
 	for k := range steps {


### PR DESCRIPTION
At leat with rhel 9 it doesnt have systemd-netword or epel-release so we need to take that into account

Still requires to run the subscription manager to register the system before running kairos-init