### PR TITLE
Fix the dirs by deploying custom binds

### DIFF
--- a/pkg/bundled/cloudconfigs/00_rootfs.yaml
+++ b/pkg/bundled/cloudconfigs/00_rootfs.yaml
@@ -15,6 +15,7 @@ stages:
         VOLUMES: "LABEL=COS_PERSISTENT:/usr/local"
         OVERLAY: "tmpfs:25%"
         RW_PATHS: "/var /etc /srv"
+        PERSISTENT_STATE_BIND: "true"
         PERSISTENT_STATE_PATHS: >-
           /etc/cni
           /etc/init.d
@@ -33,10 +34,7 @@ stages:
           /home
           /opt
           /root
-          /snap
           /usr/libexec
-          /usr/share/pki/trust
-          /usr/share/pki/trust/anchors
           /var/cores
           /var/lib/ca-certificates
           /var/lib/cni
@@ -57,8 +55,6 @@ stages:
           /var/lib/kairos
           /var/log
           /var/run/cilium
-          /var/snap
-        PERSISTENT_STATE_BIND: "true"
     - if: '[ -f "/run/cos/recovery_mode" ] && grep -vq "rd.immucore.uki" /proc/cmdline'
       # omit the persistent partition on recovery mode
       name: "Layout configuration for recovery mode"

--- a/pkg/bundled/cloudconfigs/00_rootfs.yaml
+++ b/pkg/bundled/cloudconfigs/00_rootfs.yaml
@@ -61,53 +61,6 @@ stages:
       environment_file: /run/cos/cos-layout.env
       environment:
         OVERLAY: "tmpfs:25%"
-    - if: grep -q "kairos.boot_live_mode" /proc/cmdline
-      name: "Layout configuration for booting local node from livecd"
-      environment_file: /run/cos/cos-layout.env
-      environment:
-        VOLUMES: "LABEL=COS_PERSISTENT:/usr/local"
-        OVERLAY: "tmpfs:25%"
-        RW_PATHS: "/var /etc /srv"
-        PERSISTENT_STATE_PATHS: >-
-          /etc/cni
-          /etc/init.d
-          /etc/iscsi
-          /etc/k0s
-          /etc/kubernetes
-          /etc/modprobe.d
-          /etc/pwx
-          /etc/rancher
-          /etc/runlevels
-          /etc/ssh
-          /etc/ssl/certs
-          /etc/sysconfig
-          /etc/systemd
-          /home
-          /opt
-          /root
-          /snap
-          /usr/libexec
-          /usr/share/pki/trust
-          /usr/share/pki/trust/anchors
-          /var/cores
-          /var/lib/ca-certificates
-          /var/lib/cni
-          /var/lib/containerd
-          /var/lib/calico
-          /var/lib/k0s
-          /var/lib/kubelet
-          /var/lib/longhorn
-          /var/lib/osd
-          /var/lib/rancher
-          /var/lib/rook
-          /var/lib/snapd
-          /var/lib/tailscale
-          /var/lib/wicked
-          /var/lib/kairos
-          /var/log
-          /var/run/cilium
-          /var/snap
-        PERSISTENT_STATE_BIND: "true"
     - if: '[ -e "/sbin/systemctl" ] || [ -e "/bin/systemctl" ] || [ -e "/usr/sbin/systemctl" ] || [ -e "/usr/bin/systemctl" ]'
       # Mask the commit service to avoid systemd messing with machine-id.
       # https://www.freedesktop.org/software/systemd/man/latest/systemd-machine-id-commit.service.html

--- a/pkg/bundled/cloudconfigs/00_rootfs_uki.yaml
+++ b/pkg/bundled/cloudconfigs/00_rootfs_uki.yaml
@@ -31,10 +31,7 @@ stages:
           /home
           /opt
           /root
-          /snap
           /usr/libexec
-          /usr/share/pki/trust
-          /usr/share/pki/trust/anchors
           /var/lib/ca-certificates
           /var/lib/cni
           /var/lib/containerd
@@ -49,7 +46,6 @@ stages:
           /var/lib/wicked
           /var/lib/kairos
           /var/log
-          /var/snap
     - if: '[ -e "/run/cos/uki_boot_mode" ] && ([ -e "/run/cos/recovery_mode" ] || [ -e "/run/cos/autoreset_mode" ])'
       # omit the persistent partition on recovery mode/autoreset
       name: "Layout configuration for recovery/autoreset mode on UKI"

--- a/pkg/bundled/cloudconfigs/00_rootfs_uki.yaml
+++ b/pkg/bundled/cloudconfigs/00_rootfs_uki.yaml
@@ -8,7 +8,7 @@
 name: "Rootfs Layout Settings for UKI"
 stages:
   rootfs:
-    - if: '[ -e "/run/cos/uki_boot_mode" ] && [ ! -e "/run/cos/recovery_mode" ] && [ ! -e "/run/cos/autoreset_mode" ]'
+    - if: '[ ! -f "/run/cos/recovery_mode" ] && [ -e "/run/cos/uki_boot_mode" ] && [ ! -e "/run/cos/autoreset_mode" ]'
       name: "Layout configuration for UKI boot"
       environment_file: /run/cos/cos-layout.env
       environment:

--- a/pkg/bundled/cloudconfigs/01_extra_binds.yaml
+++ b/pkg/bundled/cloudconfigs/01_extra_binds.yaml
@@ -1,0 +1,22 @@
+# This file will set specific binds for specific distros
+# both in Normal and trusted boot paths.
+# Does not apply to livecd, recovery or reset.
+name: "Extra binds for specific distros"
+stages:
+  rootfs:
+    - if: '[ ! -f "/run/cos/recovery_mode" ] && [ ! -e "/run/cos/uki_install_mode" ] && [ ! -e "/run/cos/autoreset_mode" ]'
+      only_os: "Ubuntu.*|Debian.*"
+      name: "Extra layout configuration for active/passive mode (Ubuntu/Debian)"
+      environment_file: /run/cos/extra-layout.env
+      environment:
+        PERSISTENT_STATE_PATHS: >-
+          /snap
+          /var/snap
+    - if: '[ ! -f "/run/cos/recovery_mode" ] && [ ! -e "/run/cos/uki_install_mode" ] && [ ! -e "/run/cos/autoreset_mode" ]'
+      only_os: "Red\sHat.*|CentOS.*|Fedora.*|Rocky.*|AlmaLinux.*"
+      name: "Extra layout configuration for active/passive mode (Red Hat based)"
+      environment_file: /run/cos/extra-layout.env
+      environment:
+        PERSISTENT_STATE_PATHS: >-
+          /usr/share/pki/trust
+          /usr/share/pki/trust/anchors

--- a/pkg/bundled/cloudconfigs/01_extra_binds.yaml
+++ b/pkg/bundled/cloudconfigs/01_extra_binds.yaml
@@ -13,7 +13,7 @@ stages:
           /snap
           /var/snap
     - if: '[ ! -f "/run/cos/recovery_mode" ] && [ ! -e "/run/cos/uki_install_mode" ] && [ ! -e "/run/cos/autoreset_mode" ]'
-      only_os: "Red\sHat.*|CentOS.*|Fedora.*|Rocky.*|AlmaLinux.*"
+      only_os: "Red.*Hat.*|CentOS.*|Fedora.*|Rocky.*|AlmaLinux.*"
       name: "Extra layout configuration for active/passive mode (Red Hat based)"
       environment_file: /run/cos/extra-layout.env
       environment:


### PR DESCRIPTION
Insteaf of doing workarounds, lets just deploy specific extra bind
mounts per distro so we can tweak all of them while not touching the
base ones

Signed-off-by: Itxaka <itxaka@kairos.io>