### PR TITLE
Enable networkd in rhel if its installed

### DIFF
--- a/pkg/stages/steps_init.go
+++ b/pkg/stages/steps_init.go
@@ -431,6 +431,9 @@ func GetServicesStage(_ values.System, l types.KairosLogger) []schema.Stage {
 					"dnf-makecache.timer",
 				},
 			},
+			Commands: []string{
+				"systemctl unmask getty.target", // Unmask getty.target to allow login on ttys as it comes masked by default
+			},
 		},
 		{
 			Name:                 "Enable networkd for RHEL if binary is available",

--- a/pkg/stages/steps_init.go
+++ b/pkg/stages/steps_init.go
@@ -418,6 +418,32 @@ func GetServicesStage(_ values.System, l types.KairosLogger) []schema.Stage {
 			},
 		},
 		{
+			Name:                 "Enable services for RHEL",
+			OnlyIfOs:             "Red\\sHat.*",
+			OnlyIfServiceManager: "systemd",
+			Systemctl: schema.Systemctl{
+				Enable: []string{
+					"sshd",
+					"systemd-resolved",
+				},
+				Disable: []string{
+					"dnf-makecache",
+					"dnf-makecache.timer",
+				},
+			},
+		},
+		{
+			Name:                 "Enable networkd for RHEL if binary is available",
+			OnlyIfOs:             "Red\\sHat.*",
+			OnlyIfServiceManager: "systemd",
+			If:                   "test -f /usr/lib/systemd/systemd-networkd",
+			Systemctl: schema.Systemctl{
+				Enable: []string{
+					"systemd-networkd",
+				},
+			},
+		},
+		{
 			Name:                 "Enable services for Alpine family",
 			OnlyIfOs:             "Alpine.*",
 			OnlyIfServiceManager: "openrc",

--- a/pkg/stages/steps_install.go
+++ b/pkg/stages/steps_install.go
@@ -626,7 +626,12 @@ func GetKairosInitramfsFilesStage(sis values.System, l types.KairosLogger) ([]sc
 
 		if sis.Distro == values.RedHat {
 			// On redhat we drop the systemd-networkd module as there is no systemd-networkd on rh9
-			networkModule = "network-legacy"
+			if _, err := os.Stat("/usr/lib/systemd/systemd-networkd"); err != nil && os.IsNotExist(err) {
+				l.Logger.Debug().Str("distro", string(sis.Distro)).Msg("Dropping systemd-networkd module for redhat")
+				networkModule = "network-legacy"
+			} else {
+				l.Logger.Debug().Str("distro", string(sis.Distro)).Msg("Keeping systemd-networkd module for redhat")
+			}
 		}
 
 		if sis.Distro == values.Fedora {

--- a/pkg/values/packagemaps.go
+++ b/pkg/values/packagemaps.go
@@ -412,6 +412,7 @@ var BasePackages = PackageMap{
 				"which",      // Basic tool. Basepackages?
 				"cryptsetup", // For encrypted partitions support, needed for trusted boot and dracut building
 				"tpm2-tss",   // For TPM support, mainly trusted boot
+				"xz",         // explicitely install it otherwise it will be autoremoved when the cleanup is done
 			},
 		},
 	},

--- a/pkg/values/packagemaps.go
+++ b/pkg/values/packagemaps.go
@@ -412,7 +412,7 @@ var BasePackages = PackageMap{
 				"which",      // Basic tool. Basepackages?
 				"cryptsetup", // For encrypted partitions support, needed for trusted boot and dracut building
 				"tpm2-tss",   // For TPM support, mainly trusted boot
-				"xz",         // explicitely install it otherwise it will be autoremoved when the cleanup is done
+				"xz",         // explicitly install it otherwise it will be autoremoved when the cleanup is done
 			},
 		},
 	},


### PR DESCRIPTION
It has come to our attention that some rhel users install the fedora epel and use that to enable systemd-networkd.

As the default rhel repos do not have it, we dont enable it.

This patch makes it so if the systemd-networkd binary is available we add it to the initramfs and to the enabled services so users can simple add the epel repo and install systemd-networkd and they will get the full benefits of it

It also explicitely install xz package as otherwise it will be removed during the dracut packages cleanup as nothing installed it explicitely so it wont be in the final image

Fixes https://github.com/kairos-io/kairos/issues/3473

Tested with the following Dockerfile:

```
FROM init:v1 AS kairos-init

FROM redhat/ubi9
COPY --from=kairos-init /kairos-init /kairos-init
RUN subscription-manager register --user $USER --password $PASSWORD
RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && dnf install -y systemd-networkd
RUN /kairos-init -l debug --version 0.1.1 &&  /kairos-init validate && rm /kairos-init
```


