### PR TITLE
Rename userdata folder

### DIFF
--- a/pkg/bundled/cloudconfigs/00_datasource.yaml
+++ b/pkg/bundled/cloudconfigs/00_datasource.yaml
@@ -2,30 +2,30 @@ name: "Datasource handling"
 stages:
   rootfs.before:
     - &datasource
-      if: '[ ! -e /oem/userdata ] && ([ ! -f /run/cos/uki_boot_mode ] || grep -q "kairos.pull_datasources" /proc/cmdline )'
+      if: '[ ! -e /oem/95_userdata ] && ([ ! -f /run/cos/uki_boot_mode ] || grep -q "kairos.pull_datasources" /proc/cmdline )'
       name: "Pull data from provider"
       datasource:
         providers: ["cdrom", "gcp", "openstack", "aws", "azure", "hetzner", "packet", "vultr", "digitalocean", "metaldata", "vmware", "config-drive"]
-        path: "/oem/userdata"
-    - if: '[ ! -e /oem/userdata ]'
+        path: "/oem/95_userdata"
+    - if: '[ ! -e /oem/95_userdata ]'
       name: "Sentinel file for userdata"
       files:
       - path: /run/.userdata_load
   initramfs.before:
     - <<: *datasource
-    - if: '[ ! -e /oem/userdata ]'
+    - if: '[ ! -e /oem/95_userdata ]'
       files:
       - path: /run/.userdata_load
   # After network, if no datasource could be pulled, we stop trying
   network:
     - <<: *datasource
-    - if: '[ -e /oem/userdata ] && [ -f /run/.userdata_load ]'
+    - if: '[ -e /oem/95_userdata ] && [ -f /run/.userdata_load ]'
       name: "Run stages if userdata is found"
       commands:
-      - kairos-agent run-stage initramfs --override-cloud-init-paths /oem/userdata
-      - kairos-agent run-stage boot --override-cloud-init-paths /oem/userdata
+      - kairos-agent run-stage initramfs --override-cloud-init-paths /oem/95_userdata
+      - kairos-agent run-stage boot --override-cloud-init-paths /oem/95_userdata
       - rm -rf /run/.userdata_load
-    - if: '[ ! -e /oem/userdata ] && [ -f /run/.userdata_load ]'
+    - if: '[ ! -e /oem/95_userdata ] && [ -f /run/.userdata_load ]'
       name: "Remove userdata sentinel"
       commands:
       - rm -rf /run/.userdata_load

--- a/pkg/bundled/cloudconfigs/00_datasource.yaml
+++ b/pkg/bundled/cloudconfigs/00_datasource.yaml
@@ -1,6 +1,16 @@
 name: "Datasource handling"
 stages:
   rootfs.before:
+    - &moveOldUserdata
+      name: "Move old datasource to new location"
+      if: '[ -d /oem/userdata ] && [ ! -d /oem/95_userdata ]' # If old userdata exists and new one does not
+      commands:
+      - mv -f /oem/userdata /oem/95_userdata
+    - &removeOldUserdata
+      name: "Remove old userdata"
+      if: '[ -d /oem/userdata ] && [ -d /oem/95_userdata ]' # If both exist, remove the old one
+      commands:
+      - rm -rf /oem/userdata
     - &datasource
       if: '[ ! -e /oem/95_userdata ] && ([ ! -f /run/cos/uki_boot_mode ] || grep -q "kairos.pull_datasources" /proc/cmdline )'
       name: "Pull data from provider"
@@ -12,12 +22,16 @@ stages:
       files:
       - path: /run/.userdata_load
   initramfs.before:
+    - <<: *moveOldUserdata
+    - <<: *removeOldUserdata
     - <<: *datasource
     - if: '[ ! -e /oem/95_userdata ]'
       files:
       - path: /run/.userdata_load
   # After network, if no datasource could be pulled, we stop trying
   network:
+    - <<: *moveOldUserdata
+    - <<: *removeOldUserdata
     - <<: *datasource
     - if: '[ -e /oem/95_userdata ] && [ -f /run/.userdata_load ]'
       name: "Run stages if userdata is found"


### PR DESCRIPTION
As we want to make it easier to override userdata, we rename the folder to fall in line wiht other configs we have. This way its clear that you can drop a 96_whatever.yaml and override the userdata, that userdata runs AFTER 90_custom.yaml and easier.

Part of https://github.com/kairos-io/kairos/issues/3461

Which this doesnt really fix the original issue, at least it clarifies the order visually. Then we can choose to change the order if we want, but if we do, we will be breaking the usual behaviour in which the userdata win, which is how it has worked since the start, so Im happy with just this change and a note in the docs about this.