### PR TITLE
fix: disable sysext and use tech preview resolved for rhel8

### DIFF
--- a/pkg/stages/steps_init.go
+++ b/pkg/stages/steps_init.go
@@ -2,12 +2,13 @@ package stages
 
 import (
 	"fmt"
-	"github.com/kairos-io/kairos-init/pkg/bundled"
 	"os"
 	"os/exec"
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/kairos-io/kairos-init/pkg/bundled"
 
 	semver "github.com/hashicorp/go-version"
 	"github.com/kairos-io/kairos-init/pkg/config"
@@ -538,7 +539,7 @@ func GetKernelStage(_ values.System, logger types.KairosLogger) ([]schema.Stage,
 		{ // On Fedora, if we don't have grub2 installed, it wont copy the kernel and rename it to the /boot dir, so we need to do it manually
 			// TODO: Check if this is needed on AlmaLinux/RockyLinux/Red\sHatLinux
 			Name:     "Copy kernel for Fedora Trusted Boot",
-			OnlyIfOs: "Fedora.*",
+			OnlyIfOs: "Fedora.*|Red\\sHat.*",
 			If:       fmt.Sprintf("test ! -f /boot/vmlinuz-%s && test -f /usr/lib/modules/%s/vmlinuz", kernel, kernel),
 			Commands: []string{
 				fmt.Sprintf("cp /usr/lib/modules/%s/vmlinuz /boot/vmlinuz-%s", kernel, kernel),

--- a/pkg/values/packagemaps.go
+++ b/pkg/values/packagemaps.go
@@ -2,12 +2,14 @@ package values
 
 import (
 	"bytes"
+
 	"github.com/kairos-io/kairos-init/pkg/config"
+
+	"text/template"
 
 	semver "github.com/hashicorp/go-version"
 	sdkTypes "github.com/kairos-io/kairos-sdk/types"
 )
-import "text/template"
 
 // packagemaps is a map of packages to install for each distro.
 // so we can deal with stupid different names between distros.
@@ -407,12 +409,14 @@ var BasePackages = PackageMap{
 				"openssh-clients",
 				"polkit",
 				"qemu-guest-agent",
-				"systemd", // Basic tool.
-				"systemd-resolved",
+				"systemd",    // Basic tool.
 				"which",      // Basic tool. Basepackages?
 				"cryptsetup", // For encrypted partitions support, needed for trusted boot and dracut building
 				"tpm2-tss",   // For TPM support, mainly trusted boot
 				"xz",         // explicitly install it otherwise it will be autoremoved when the cleanup is done
+			},
+			">=9.0": {
+				"systemd-resolved", // systemd-resolved is tech preview in systemd before 9.0
 			},
 		},
 	},


### PR DESCRIPTION
* update package and kernel path expectations for RHEL8.10.
* systemd-resloved is tech preview in RHEL8.10 and must be enabled during build


Example Dockerfile
```
# Dockerfile for creating a custom Kairos image

# Use build arguments to make the image configurable
ARG BASE_IMAGE=redhat/ubi8
ARG KAIROS_INIT_VERSION=v0.5.0

# First stage: Get kairos-init
#FROM quay.io/kairos/kairos-init:${KAIROS_INIT_VERSION} AS kairos-init
FROM ghcr.io/bdegeeter/kairos-init:rhel8 AS kairos-init

# Second stage: Build the Kairos image
FROM ${BASE_IMAGE} AS base-kairos

# Set build arguments with defaults
ARG VARIANT=core
ARG MODEL=generic
ARG TRUSTED_BOOT=false
ARG KUBERNETES_DISTRO=k3s
ARG KUBERNETES_VERSION=latest
ARG FRAMEWORK_VERSION=v2.20.0
ARG VERSION=1.0.0


ARG RHEL_USERNAME
ARG RHEL_PASSWORD


# Install EPEL repository for RHEL/UBI

RUN . /etc/os-release && \
  if [ "$ID" = "rhel" ]; then \
  MAJOR_VERSION=$(echo $VERSION_ID | cut -d. -f1) && \
  dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-${MAJOR_VERSION}.noarch.rpm && dnf clean all && \
  echo "RHEL detected, registering system..." && \
  rm -f /etc/rhsm-host && \
  subscription-manager register --username ${RHEL_USERNAME} --password "${RHEL_PASSWORD}" && \
  yum repolist && \
  subscription-manager attach --auto && \
  subscription-manager repos --enable rhel-${MAJOR_VERSION}-for-x86_64-appstream-rpms && \
  yum repolist; \
  subscription-manager status; \
  if [ $? -ne 0 ]; then \
  echo "RHEL subscription failed"; \
  exit 1; \
  fi; \
  else \
  echo "Skipping RHEL subscription, OS ID is $ID"; \
  fi

# Copy kairos-init from the first stage
COPY --from=kairos-init /kairos-init /kairos-init

# Work around for https://github.com/kairos-io/kairos-init/issues/121
RUN dnf install -y systemd-networkd 

# Only enable systemd-resolved if it's rhel version 8
RUN . /etc/os-release && \
  if [ "$ID" = "rhel" ] && [ "$VERSION_ID" = "8" ]; then \
  systemctl enable systemd-resolved; \
  fi


RUN /kairos-init -l debug -m "${MODEL}" -v "${VARIANT}" -t "${TRUSTED_BOOT}" --version "${VERSION}"
RUN /kairos-init validate -t "${TRUSTED_BOOT}"
#
# Clean up
RUN rm /kairos-init

# Work around for https://github.com/kairos-io/kairos-init/pull/125
RUN systemctl unmask getty.target

```