### PR TITLE
Fix timesync being masked

### DIFF
--- a/pkg/stages/steps_init.go
+++ b/pkg/stages/steps_init.go
@@ -380,7 +380,6 @@ func GetServicesStage(_ values.System, l types.KairosLogger) []schema.Stage {
 			Systemctl: schema.Systemctl{
 				Enable: []string{
 					"fail2ban",
-					"systemd-timesyncd",
 				},
 				Mask: []string{
 					"systemd-firstboot.service",
@@ -390,6 +389,16 @@ func GetServicesStage(_ values.System, l types.KairosLogger) []schema.Stage {
 						Service: "systemd-networkd-wait-online",
 						Content: bundled.SystemdNetworkOnlineWaitOverride,
 					},
+				},
+			},
+		},
+		{
+			Name:                 "Enable timesyncd service",
+			OnlyIfServiceManager: "systemd",
+			OnlyIfOs:             "Ubuntu.*|Debian.*|Fedora.*|CentOS.*|SLES.*|[O-o]penSUSE.*", // RHEL family
+			Systemctl: schema.Systemctl{
+				Enable: []string{
+					"systemd-timesyncd",
 				},
 			},
 		},

--- a/pkg/stages/steps_init.go
+++ b/pkg/stages/steps_init.go
@@ -380,10 +380,10 @@ func GetServicesStage(_ values.System, l types.KairosLogger) []schema.Stage {
 			Systemctl: schema.Systemctl{
 				Enable: []string{
 					"fail2ban",
+					"systemd-timesyncd",
 				},
 				Mask: []string{
 					"systemd-firstboot.service",
-					"systemd-timesyncd.service",
 				},
 				Overrides: []schema.SystemctlOverride{
 					{


### PR DESCRIPTION
Wrongly removed from here: https://github.com/kairos-io/kairos-init/pull/127/files#diff-c3119fb2dd38c2610e25045c96cf2c0e4fd1d669f71ce40606648a81170b56b2L24 and instead of updating it to enable it I masked it.