### PR TITLE
Fix suse builds network

### DIFF
--- a/pkg/stages/steps_init.go
+++ b/pkg/stages/steps_init.go
@@ -414,6 +414,31 @@ func GetServicesStage(_ values.System, l types.KairosLogger) []schema.Stage {
 			},
 		},
 		{
+			Name:                 "Disable Wicked for SUSE family", // Collides with systemd-networkd
+			OnlyIfOs:             "SLES.*|[O-o]penSUSE.*",
+			OnlyIfServiceManager: "systemd",
+			Systemctl: schema.Systemctl{
+				Disable: []string{
+					"wicked",
+				},
+				Mask: []string{
+					"wicked",
+				},
+			},
+		},
+		{
+			Name:                 "Enable services for SUSE family",
+			OnlyIfOs:             "SLES.*|[O-o]penSUSE.*",
+			OnlyIfServiceManager: "systemd",
+			Systemctl: schema.Systemctl{
+				Enable: []string{
+					"sshd",
+					"systemd-networkd",
+					"systemd-resolved",
+				},
+			},
+		},
+		{
 			Name:                 "Enable services for RHEL family",
 			OnlyIfOs:             "Fedora.*|CentOS.*|Rocky.*|AlmaLinux.*",
 			OnlyIfServiceManager: "systemd",

--- a/pkg/stages/steps_init.go
+++ b/pkg/stages/steps_init.go
@@ -415,7 +415,7 @@ func GetServicesStage(_ values.System, l types.KairosLogger) []schema.Stage {
 		},
 		{
 			Name:                 "Disable Wicked for SUSE family", // Collides with systemd-networkd
-			OnlyIfOs:             "SLES.*|[O-o]penSUSE.*",
+			OnlyIfOs:             "SLES.*|openSUSE.*",
 			OnlyIfServiceManager: "systemd",
 			Systemctl: schema.Systemctl{
 				Disable: []string{
@@ -428,7 +428,7 @@ func GetServicesStage(_ values.System, l types.KairosLogger) []schema.Stage {
 		},
 		{
 			Name:                 "Enable services for SUSE family",
-			OnlyIfOs:             "SLES.*|[O-o]penSUSE.*",
+			OnlyIfOs:             "SLES.*|openSUSE.*",
 			OnlyIfServiceManager: "systemd",
 			Systemctl: schema.Systemctl{
 				Enable: []string{

--- a/pkg/values/packagemaps.go
+++ b/pkg/values/packagemaps.go
@@ -318,6 +318,13 @@ var BasePackages = PackageMap{
 			},
 		},
 	},
+	OpenSUSETumbleweed: {
+		ArchCommon: {
+			Common: {
+				"systemd-resolved",
+			},
+		},
+	},
 	AlpineFamily: {
 		ArchCommon: {
 			Common: {


### PR DESCRIPTION
We need to disable and mask wicked as it comes as a dep of something and breaks systemd-networkd enablement

This mimics what we had on the old dockerfiles