### PR TITLE
Split packages and kernel install

### DIFF
--- a/pkg/stages/stages.go
+++ b/pkg/stages/stages.go
@@ -78,6 +78,14 @@ func RunInstallStage(logger types.KairosLogger) (schema.YipConfig, error) {
 		return data, err
 	}
 	data.Stages["install"] = installStage
+
+	// Get kernel stage
+	kernelStage, err := GetKernelStage(sis, logger)
+	if err != nil {
+		logger.Logger.Error().Msgf("Failed to get the kernel stage: %s", err)
+		return data, err
+	}
+	data.Stages["install"] = append(data.Stages["install"], kernelStage...)
 	// Add the branding files
 	data.Stages["install"] = append(data.Stages["install"], GetInstallBrandingStage(sis, logger)...)
 	// Add the bootargs file

--- a/pkg/stages/stages.go
+++ b/pkg/stages/stages.go
@@ -80,7 +80,7 @@ func RunInstallStage(logger types.KairosLogger) (schema.YipConfig, error) {
 	data.Stages["install"] = installStage
 
 	// Get kernel stage
-	kernelStage, err := GetKernelStage(sis, logger)
+	kernelStage, err := GetInstallKernelStage(sis, logger)
 	if err != nil {
 		logger.Logger.Error().Msgf("Failed to get the kernel stage: %s", err)
 		return data, err

--- a/pkg/values/packagemaps.go
+++ b/pkg/values/packagemaps.go
@@ -766,38 +766,12 @@ func GetPackages(s System, l sdkTypes.KairosLogger) ([]string, error) {
 	}
 	// If trusted boot is enabled, we need to install the trusted boot packages
 	if config.DefaultConfig.TrustedBoot {
-		// Kernel packages by model
-		if config.DefaultConfig.Model == Generic.String() {
-			filteredPackages = append(filteredPackages, KernelPackagesTrustedBoot[s.Distro][ArchCommon]) // Common kernel packages to both arches
-			filteredPackages = append(filteredPackages, KernelPackagesTrustedBoot[s.Family][ArchCommon]) // Common kernel packages to both arches by family
-			filteredPackages = append(filteredPackages, KernelPackagesTrustedBoot[s.Distro][s.Arch])     // Specific kernel packages for the arch
-			filteredPackages = append(filteredPackages, KernelPackagesTrustedBoot[s.Family][s.Arch])     // Specific kernel packages for the arch by family
-		} else {
-			// Get specific packages for the model
-			// TODO: No support for trusted boot on models yet, so this part is probably useless for now?
-			filteredPackages = append(filteredPackages, KernelPackagesModels[s.Distro][ArchCommon][Model(config.DefaultConfig.Model)])
-			filteredPackages = append(filteredPackages, KernelPackagesModels[s.Family][ArchCommon][Model(config.DefaultConfig.Model)])
-			filteredPackages = append(filteredPackages, KernelPackagesModels[s.Distro][s.Arch][Model(config.DefaultConfig.Model)])
-			filteredPackages = append(filteredPackages, KernelPackagesModels[s.Family][s.Arch][Model(config.DefaultConfig.Model)])
-		}
 		// Install only systemd-boot packages
 		filteredPackages = append(filteredPackages, SystemdPackages[s.Distro][ArchCommon])
 		filteredPackages = append(filteredPackages, SystemdPackages[s.Family][ArchCommon])
 		filteredPackages = append(filteredPackages, SystemdPackages[s.Distro][s.Arch])
 		filteredPackages = append(filteredPackages, SystemdPackages[s.Family][s.Arch])
 	} else {
-		if config.DefaultConfig.Model == Generic.String() {
-			filteredPackages = append(filteredPackages, KernelPackages[s.Distro][ArchCommon]) // Common kernel packages to both arches
-			filteredPackages = append(filteredPackages, KernelPackages[s.Family][ArchCommon]) // Common kernel packages to both arches by family
-			filteredPackages = append(filteredPackages, KernelPackages[s.Distro][s.Arch])     // Specific kernel packages for the arch
-			filteredPackages = append(filteredPackages, KernelPackages[s.Family][s.Arch])     // Specific kernel packages for the arch by family
-		} else {
-			// Get specific packages for the model
-			filteredPackages = append(filteredPackages, KernelPackagesModels[s.Distro][ArchCommon][Model(config.DefaultConfig.Model)])
-			filteredPackages = append(filteredPackages, KernelPackagesModels[s.Family][ArchCommon][Model(config.DefaultConfig.Model)])
-			filteredPackages = append(filteredPackages, KernelPackagesModels[s.Distro][s.Arch][Model(config.DefaultConfig.Model)])
-			filteredPackages = append(filteredPackages, KernelPackagesModels[s.Family][s.Arch][Model(config.DefaultConfig.Model)])
-		}
 		// install grub and immucore packages
 		filteredPackages = append(filteredPackages, GrubPackages[s.Distro][ArchCommon])
 		filteredPackages = append(filteredPackages, GrubPackages[s.Family][ArchCommon])
@@ -812,6 +786,43 @@ func GetPackages(s System, l sdkTypes.KairosLogger) ([]string, error) {
 	mergedPkgs = append(mergedPkgs, FilterPackagesOnConstraint(s, l, filteredPackages)...)
 
 	return mergedPkgs, nil
+}
+
+func GetKernelPackages(s System, l sdkTypes.KairosLogger) ([]string, error) {
+	// Get the kernel packages for the system
+	var filteredPackages []VersionMap
+
+	if config.DefaultConfig.TrustedBoot {
+		// Kernel packages by model
+		if config.DefaultConfig.Model == Generic.String() {
+			filteredPackages = append(filteredPackages, KernelPackagesTrustedBoot[s.Distro][ArchCommon]) // Common kernel packages to both arches
+			filteredPackages = append(filteredPackages, KernelPackagesTrustedBoot[s.Family][ArchCommon]) // Common kernel packages to both arches by family
+			filteredPackages = append(filteredPackages, KernelPackagesTrustedBoot[s.Distro][s.Arch])     // Specific kernel packages for the arch
+			filteredPackages = append(filteredPackages, KernelPackagesTrustedBoot[s.Family][s.Arch])     // Specific kernel packages for the arch by family
+		} else {
+			// Get specific packages for the model
+			// TODO: No support for trusted boot on models yet, so this part is probably useless for now?
+			filteredPackages = append(filteredPackages, KernelPackagesModels[s.Distro][ArchCommon][Model(config.DefaultConfig.Model)])
+			filteredPackages = append(filteredPackages, KernelPackagesModels[s.Family][ArchCommon][Model(config.DefaultConfig.Model)])
+			filteredPackages = append(filteredPackages, KernelPackagesModels[s.Distro][s.Arch][Model(config.DefaultConfig.Model)])
+			filteredPackages = append(filteredPackages, KernelPackagesModels[s.Family][s.Arch][Model(config.DefaultConfig.Model)])
+		}
+	} else {
+		if config.DefaultConfig.Model == Generic.String() {
+			filteredPackages = append(filteredPackages, KernelPackages[s.Distro][ArchCommon]) // Common kernel packages to both arches
+			filteredPackages = append(filteredPackages, KernelPackages[s.Family][ArchCommon]) // Common kernel packages to both arches by family
+			filteredPackages = append(filteredPackages, KernelPackages[s.Distro][s.Arch])     // Specific kernel packages for the arch
+			filteredPackages = append(filteredPackages, KernelPackages[s.Family][s.Arch])     // Specific kernel packages for the arch by family
+		} else {
+			// Get specific packages for the model
+			filteredPackages = append(filteredPackages, KernelPackagesModels[s.Distro][ArchCommon][Model(config.DefaultConfig.Model)])
+			filteredPackages = append(filteredPackages, KernelPackagesModels[s.Family][ArchCommon][Model(config.DefaultConfig.Model)])
+			filteredPackages = append(filteredPackages, KernelPackagesModels[s.Distro][s.Arch][Model(config.DefaultConfig.Model)])
+			filteredPackages = append(filteredPackages, KernelPackagesModels[s.Family][s.Arch][Model(config.DefaultConfig.Model)])
+		}
+	}
+	// Return filtered packages
+	return FilterPackagesOnConstraint(s, l, filteredPackages), nil
 }
 
 // FilterPackagesOnConstraint filters the packages based on the system version and the constraints in the package map

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -94,6 +94,7 @@ const (
 	InitStage            = "init"             // Full init stage
 	InstallStage         = "install"          // Full install stage
 	InstallPackagesStep  = "installPackages"  // Installs the base system packages
+	InstallKernelStep    = "installKernel"    // Installs the kernel packages
 	InitrdStep           = "initrd"           // Generates the initrd
 	KairosReleaseStep    = "kairosRelease"    // Creates and fills the /etc/kairos-release file
 	WorkaroundsStep      = "workarounds"      // Applies workarounds for known issues
@@ -116,6 +117,7 @@ func StepsInfo() []StepInfo {
 		InitStage:            "The full init stage, which includes kairosRelease, kubernetes, initrd, services, workarounds and cleanup steps",
 		InstallStage:         "The full install stage, which includes installPackages, kubernetes, cloudconfigs, branding, grub, services, kairosBinaries, providerBinaries, initramfsConfigs and miscellaneous steps",
 		InstallPackagesStep:  "installs the base system packages",
+		InstallKernelStep:    "installs the kernel packages",
 		InitrdStep:           "generates the initrd",
 		KairosReleaseStep:    "creates and fills the /etc/kairos-release file",
 		WorkaroundsStep:      "applies workarounds for known issues",


### PR DESCRIPTION
This allows more control over the stages to install, especially if we want to separate the kernel or skip it and manually install specific kernel or firmware packages manually

Fixes https://github.com/kairos-io/kairos/issues/3494