### PR TITLE
Remove python3-pynvim from Debian family base packages

### DIFF
--- a/pkg/values/packagemaps.go
+++ b/pkg/values/packagemaps.go
@@ -266,7 +266,6 @@ var BasePackages = PackageMap{
 				"pkg-config",
 				"psmisc",
 				"publicsuffix",
-				"python3-pynvim",
 				"shared-mime-info",
 				"systemd", // Basic tool.
 				"systemd-timesyncd",


### PR DESCRIPTION
## What this PR does / why we need it

This PR removes the `python3-pynvim` package from the Debian family base packages in `packagemaps.go`.

## Which issue(s) this PR fixes

This change optimizes base image size and reduces unnecessary dependencies.

## Details

The `python3-pynvim` package provides Python plugin support for Neovim through the msgpack-rpc API. While this functionality can be useful for power users, it has several drawbacks for base Kairos images:

1. **Unnecessary dependency**: The package is not essential for the core Kairos functionality
2. **Image size impact**: Installing `python3-pynvim` automatically pulls in the entire Python3 runtime and its dependencies, significantly increasing base image size
3. **Optional functionality**: Python plugin support for Neovim is a specialized feature that most users don't require
4. **Still available when needed**: Users who need this functionality can easily install it manually or through their own customizations

## Changes made

- Removed `python3-pynvim` from the `DebianFamily` → `ArchCommon` → `Common` package list in `pkg/values/packagemaps.go`
- No test changes required as there are no specific tests for package lists
- No configuration changes needed as this package wasn't referenced elsewhere in the codebase

## Testing

- [x] Code compiles without errors
- [x] No syntax errors in packagemaps.go
- [x] No references to the removed package found in the codebase
- [x] Neovim itself remains available in the package list for users who need it

## Notes

This change aligns with the goal of keeping base Kairos images lean while maintaining all essential functionality. Users who require Python plugin support for Neovim can add it to their custom images or install it post-deployment.
