### PR TITLE
Disable grub2 trigger after install

### DIFF
--- a/pkg/stages/steps_install.go
+++ b/pkg/stages/steps_install.go
@@ -67,6 +67,16 @@ func GetInstallStage(sis values.System, logger types.KairosLogger) ([]schema.Sta
 			},
 		},
 		{
+			Name:     "Disable grub2 probe trigger", // Grub2 will try to probe the system on install, which fails due it being on a container
+			OnlyIfOs: "Alpine.*",
+			Files: []schema.File{
+				{
+					Path:    "/etc/update-grub.conf",
+					Content: "disable_trigger=1",
+				},
+			},
+		},
+		{
 			Name: "Install base packages",
 			Packages: schema.Packages{
 				Install: finalMergedPkgs,


### PR DESCRIPTION
Seems like grub2 package is triggering after install and trying to probe the disks of the system and the rootfs but as we are on a container it gets confused due to the overlay and it will mark the package as failed and wont be able to run any other apk commands without getting an error exit status.

This fixes it by setting the expected sentinel to avoid grub2 trigger the os-prober during install which results in apk staying in a good status

Fixes https://github.com/kairos-io/kairos/issues/3529