### PR TITLE
Improve mkinitfs under alpine

### DIFF
--- a/pkg/stages/steps_install.go
+++ b/pkg/stages/steps_install.go
@@ -77,11 +77,29 @@ func GetInstallStage(sis values.System, logger types.KairosLogger) ([]schema.Sta
 			},
 		},
 		{
+			Name:     "Disable mkinitfs trigger", // mkinitfs will generate an initramfs file but we dont need it
+			OnlyIfOs: "Alpine.*",
+			Files: []schema.File{
+				{
+					Path:    "/etc/mkinitfs/mkinitfs.conf",
+					Content: "disable_trigger=true",
+				},
+			},
+		},
+		{
 			Name: "Install base packages",
 			Packages: schema.Packages{
 				Install: finalMergedPkgs,
 				Refresh: true,
 				Upgrade: true,
+			},
+		},
+		{
+			Name:     "Restore mkinitfs default config", // restore the mkinitfs default config to its proper place
+			OnlyIfOs: "Alpine.*",
+			If:       "test -f /etc/mkinitfs/mkinitfs.conf.apk-new",
+			Commands: []string{
+				"mv /etc/mkinitfs/mkinitfs.conf.apk-new /etc/mkinitfs/mkinitfs.conf",
 			},
 		},
 	}


### PR DESCRIPTION
On the first install mkinitfs will create an automatic initramfs due to its package trigger.

This initramfs is useless to us as it doesnt contain what we need on it, so we always end up removing it afterwards.

Instead, just skip the trigger vi setting it into the mkinitfs config file before installing and then restore the package mkinifs config file to its proper place. This should save some time while installing and not waste time into creating uneeded files