### PR TITLE
Track embeded binary info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ immucore-fips_URL := $(call URL_TEMPLATE,immucore,$(IMMUCORE_VERSION),-fips)
 kcrypt-discovery-challenger-fips_URL := $(call URL_TEMPLATE,kcrypt-discovery-challenger,$(KCRYPT_DISCOVERY_CHALLENGER_VERSION),-fips)
 provider-kairos-fips_URL := $(call URL_TEMPLATE,provider-kairos,$(PROVIDER_KAIROS_VERSION),-fips)
 
-.PHONY: all prepare download compress cleanup
+.PHONY: all prepare download compress cleanup version-info
 
-all: prepare download compress cleanup
+all: prepare download compress cleanup version-info
 
 # Clean the output directory
 prepare:
@@ -83,3 +83,15 @@ cleanup:
 	@echo "Cleaning up non-binary files..."
 	@find $(OUTPUT_DIR) -type f ! -exec file {} \; | grep -v "executable" | awk -F: '{print $$1}' | xargs -r rm -f
 	@find $(OUTPUT_DIR_FIPS) -type f ! -exec file {} \; | grep -v "executable" | awk -F: '{print $$1}' | xargs -r rm -f
+
+# Add version info config to the bundled binaries dir into a single yaml file
+version-info:
+	@echo "Adding version info to the bundled binaries directory..."
+	@mkdir -p $(OUTPUT_DIR)
+	@echo "kairos-agent: $(AGENT_VERSION)" > $(OUTPUT_DIR)/version-info.yaml
+	@echo "immucore: $(IMMUCORE_VERSION)" >> $(OUTPUT_DIR)/version-info.yaml
+	@echo "kcrypt-discovery-challenger: $(KCRYPT_DISCOVERY_CHALLENGER_VERSION)" >> $(OUTPUT_DIR)/version-info.yaml
+	@echo "provider-kairos: $(PROVIDER_KAIROS_VERSION)" >> $(OUTPUT_DIR)/version-info.yaml
+	@echo "edgevpn: $(EDGEVPN_VERSION)" >> $(OUTPUT_DIR)/version-info.yaml
+	@echo "version-info.yaml created in $(OUTPUT_DIR)"
+

--- a/main.go
+++ b/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"github.com/kairos-io/kairos-init/pkg/bundled"
+	"gopkg.in/yaml.v3"
 	"os"
 	"strings"
 
@@ -64,6 +66,29 @@ var stepsInfo = &cobra.Command{
 			logger.Infof("\"%s\": %s", stepsInfo[step].Key, stepsInfo[step].Value)
 		}
 		logger.Infof("--------------------------------------------------------")
+	},
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version of kairos-init and bundled binaries",
+	Long:  `Print the version of kairos-init and bundled binaries. If other binary versions are selected, those are not shown, only the embedded ones`,
+	Run: func(cmd *cobra.Command, args []string) {
+		logger := types.NewKairosLogger("kairos-init", "info", false)
+		logger.Infof("kairos-init version %s", values.GetVersion())
+		logger.Debug(litter.Sdump(values.GetFullVersion()))
+
+		// parse embeded version info for binaries
+		versionInfo := map[string]string{}
+		err := yaml.Unmarshal(bundled.EmbeddedVersionInfo, &versionInfo)
+		if err != nil {
+			logger.Errorf("Error parsing embedded version info: %v", err)
+			return
+		}
+		logger.Infof("Embedded version info:")
+		for key, value := range versionInfo {
+			logger.Infof("%s: %s", key, value)
+		}
 	},
 }
 
@@ -159,6 +184,7 @@ func init() {
 
 	rootCmd.AddCommand(validateCmd)
 	rootCmd.AddCommand(stepsInfo)
+	rootCmd.AddCommand(versionCmd)
 }
 
 func main() {

--- a/pkg/bundled/bundled.go
+++ b/pkg/bundled/bundled.go
@@ -33,6 +33,9 @@ var EmbeddedKairosProviderFips []byte
 //go:embed binaries/edgevpn
 var EmbeddedEdgeVPN []byte
 
+//go:embed binaries/version-info.yaml
+var EmbeddedVersionInfo []byte
+
 // EmbeddedConfigs contains the cloudconfigs that go into /system/oem
 //
 //go:embed cloudconfigs/*


### PR DESCRIPTION
And provide a command to show the kairos-init version and embedded binaries


```
# itxaka @ mac in ~/projects/kairos-init on git:main x [13:39:53] 
$ go run . version
2025-08-04T13:40:57+02:00 INF kairos-init version v0.0.1
2025-08-04T13:40:57+02:00 INF Embedded version info:
2025-08-04T13:40:57+02:00 INF immucore: v0.11.2
2025-08-04T13:40:57+02:00 INF kcrypt-discovery-challenger: v0.11.2
2025-08-04T13:40:57+02:00 INF provider-kairos: v2.13.2
2025-08-04T13:40:57+02:00 INF edgevpn: v0.30.2
2025-08-04T13:40:57+02:00 INF kairos-agent: v2.24.1
```

Fixes https://github.com/kairos-io/kairos/issues/3549