### PR TITLE
Add missing mkfs binaries to alpine init

### DIFF
--- a/pkg/bundled/alpineInit/immucore.files
+++ b/pkg/bundled/alpineInit/immucore.files
@@ -9,6 +9,7 @@
 /sbin/e2fsck
 /sbin/openrc
 /sbin/openrc-run
+/sbin/mkfs.*
 /etc/udev/*
 /lib/udev/*
 /usr/lib/udev/*


### PR DESCRIPTION
Missing those binaries, the raw images would fail to expand the system on first boot

Fixes https://github.com/kairos-io/kairos/issues/3564