### PR TITLE
remove reference to tpm packages in arm for suse family

### DIFF
--- a/pkg/values/packagemaps.go
+++ b/pkg/values/packagemaps.go
@@ -317,6 +317,10 @@ var BasePackages = PackageMap{
 				"tmux",
 				"vim",
 				"which",
+			},
+		},
+		ArchAMD64: {
+			Common: {
 				"tpm2*",
 			},
 		},


### PR DESCRIPTION
I think this would be a safe fix for the issues building tumbleweed on main atm