### PR TITLE
overwrite ubuntu 25.04 hostonly=yes

### DIFF
--- a/pkg/bundled/bundled.go
+++ b/pkg/bundled/bundled.go
@@ -138,7 +138,7 @@ const (
 	DracutFipsPath                = "/etc/dracut.conf.d/kairos-fips.conf"
 	DracutSysextPath              = "/etc/dracut.conf.d/kairos-sysext.conf"
 	DracutNetworkPath             = "/etc/dracut.conf.d/kairos-network.conf"
-	DracutConfigPath              = "/etc/dracut.conf.d/10-immucore.conf"
+	DracutConfigPath              = "/etc/dracut.conf.d/99-immucore.conf"
 	DracutImmucoreModuleSetupPath = "/usr/lib/dracut/modules.d/28immucore/module-setup.sh"
 	DracutImmucoreGeneratorPath   = "/usr/lib/dracut/modules.d/28immucore/generator.sh"
 	DracutImmucoreServicePath     = "/usr/lib/dracut/modules.d/28immucore/immucore.service"

--- a/pkg/stages/steps_init.go
+++ b/pkg/stages/steps_init.go
@@ -49,10 +49,10 @@ func GetInitrdStage(sys values.System, logger types.KairosLogger) ([]schema.Stag
 			return []schema.Stage{}, err
 		}
 
-		dracutCmd := fmt.Sprintf("dracut -f /boot/initrd %s --no-hostonly", kernel)
+		dracutCmd := fmt.Sprintf("dracut -f /boot/initrd %s", kernel)
 
 		if logger.GetLevel() == 0 {
-			dracutCmd = fmt.Sprintf("dracut -v -f /boot/initrd %s --no-hostonly", kernel)
+			dracutCmd = fmt.Sprintf("dracut -v -f /boot/initrd %s", kernel)
 		}
 
 		stage = append(stage, []schema.Stage{


### PR DESCRIPTION
Ubuntu 24.04 by default sets hostonly to true and sloppy mode

```
root@5d79bf6ef04b:/# grep -R "hostonly" /usr/lib/dracut/dracut.conf.d /etc/dracut.conf* | sort
/usr/lib/dracut/dracut.conf.d/10-ubuntu.conf:hostonly="yes"
/usr/lib/dracut/dracut.conf.d/10-ubuntu.conf:hostonly_mode="sloppy"
/usr/lib/dracut/dracut.conf.d/generic/50-generic.conf:hostonly="no"
/usr/lib/dracut/dracut.conf.d/hostonly/50-hostonly.conf:hostonly="yes"
/usr/lib/dracut/dracut.conf.d/rescue/50-rescue.conf:hostonly="no"
/usr/lib/dracut/dracut.conf.d/uki-virt/50-uki-virt.conf:hostonly="no"
```