### PR TITLE
🐛 fix(init): skip grub2-editenv link creation if it already exists

### DIFF
--- a/pkg/stages/steps_init.go
+++ b/pkg/stages/steps_init.go
@@ -222,7 +222,8 @@ func GetWorkaroundsStage(sis values.System, l types.KairosLogger) []schema.Stage
 		{
 			Name: "Link grub-editenv to grub2-editenv",
 			//OnlyIfOs: "Ubuntu.*|Alpine.*", // Maybe not needed and just checking if the file exists is enough
-			If: "test -f /usr/bin/grub-editenv",
+			// test if the file exists and if the link does not exist
+			If: "test -f /usr/bin/grub-editenv && ! test -f /usr/bin/grub2-editenv",
 			Commands: []string{
 				"ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv",
 			},


### PR DESCRIPTION
This PR fixes #204 

#### Problem

On Ubuntu 24.04, `/usr/bin/grub2-editenv` already exists (usually provided by the GRUB packages).
During the `init` stage, `kairos-init` always attempts to run:

```sh
ln -s /usr/bin/grub-editenv /usr/bin/grub2-editenv
```

This fails with:

```
ln: failed to create symbolic link '/usr/bin/grub2-editenv': File exists
```

and causes the whole build process to stop.

#### Solution

Update the condition in `steps_init.go` to only create the symlink if:

* `/usr/bin/grub-editenv` exists **and**
* `/usr/bin/grub2-editenv` does **not** already exist.

```diff
- If: "test -f /usr/bin/grub-editenv",
+ // test if the file exists and if the link does not exist
+ If: "test -f /usr/bin/grub-editenv && ! test -e /usr/bin/grub2-editenv",
```