### PR TITLE
Remove 'patch' package from package lists

### DIFF
--- a/pkg/values/packagemaps.go
+++ b/pkg/values/packagemaps.go
@@ -262,7 +262,6 @@ var BasePackages = PackageMap{
 				"openssh-server",
 				"open-vm-tools",
 				"os-prober",
-				"patch",
 				"pigz",
 				"pkg-config",
 				"psmisc",
@@ -569,7 +568,6 @@ var GrubPackages = PackageMap{
 		ArchCommon: {
 			Common: {
 				"nethogs",
-				"patch",
 				"shim",
 				"iw",
 			},


### PR DESCRIPTION
Removed 'patch' from the list of packages in SUSEFamily and other sections.