### PR TITLE
fix: Remove 'issue-generator' from Tumbleweed package list

### DIFF
--- a/pkg/values/packagemaps.go
+++ b/pkg/values/packagemaps.go
@@ -296,7 +296,6 @@ var BasePackages = PackageMap{
 				"htop",
 				"iproute2",
 				"iputils",
-				"issue-generator",
 				"lsscsi",
 				"mdadm",
 				"multipath-tools",
@@ -321,6 +320,20 @@ var BasePackages = PackageMap{
 		ArchAMD64: {
 			Common: {
 				"tpm2*",
+			},
+		},
+	},
+	OpenSUSELeap: {
+		ArchCommon: {
+			Common: {
+				"issue-generator", // Broken on tumbleweed
+			},
+		},
+	},
+	SLES: {
+		ArchCommon: {
+			Common: {
+				"issue-generator", // Broken on tumbleweed
 			},
 		},
 	},


### PR DESCRIPTION
- Removed 'issue-generator' from the package list for OpenSUSE Tumbleweed as it is broken.
- Added 'issue-generator' back to the package list for OpenSUSE Leap and SLES to maintain compatibility.