### PR TITLE
fix: Remove unnecessary binaries from immucore.files

### DIFF
--- a/pkg/bundled/alpineInit/immucore.files
+++ b/pkg/bundled/alpineInit/immucore.files
@@ -9,7 +9,6 @@
 /sbin/e2fsck
 /sbin/openrc
 /sbin/openrc-run
-/sbin/mkfs.*
 /etc/udev/*
 /lib/udev/*
 /usr/lib/udev/*
@@ -17,8 +16,5 @@
 /usr/bin/immucore
 /usr/bin/kairos-agent
 /usr/bin/rsync
-/usr/bin/sgdisk
 /usr/bin/dbus-uuidgen
 /usr/sbin/multipath
-/usr/sbin/resize2fs
-/usr/sbin/xfs_growfs

--- a/pkg/bundled/alpineInit/immucore.files
+++ b/pkg/bundled/alpineInit/immucore.files
@@ -18,10 +18,7 @@
 /usr/bin/kairos-agent
 /usr/bin/rsync
 /usr/bin/sgdisk
-/usr/bin/growpart
 /usr/bin/dbus-uuidgen
 /usr/sbin/multipath
-/usr/sbin/parted
-/usr/sbin/partprobe
 /usr/sbin/resize2fs
 /usr/sbin/xfs_growfs

--- a/pkg/bundled/bundled.go
+++ b/pkg/bundled/bundled.go
@@ -240,7 +240,7 @@ install() {
 
     inst_check_multiple immucore kairos-agent
     # add utils used by yip stages
-    inst_check_multiple sync udevadm mkfs.ext2 mkfs.ext3 mkfs.ext4 mkfs.vfat mkfs.fat blkid lsblk e2fsck resize2fs mount umount sgdisk rsync cryptsetup gawk awk
+    inst_check_multiple sync udevadm blkid lsblk e2fsck mount umount rsync cryptsetup gawk awk
 
     # Install libraries needed by gawk
     inst_libdir_file "libsigsegv.so*"

--- a/pkg/bundled/bundled.go
+++ b/pkg/bundled/bundled.go
@@ -240,7 +240,7 @@ install() {
 
     inst_check_multiple immucore kairos-agent
     # add utils used by yip stages
-    inst_check_multiple partprobe sync udevadm parted mkfs.ext2 mkfs.ext3 mkfs.ext4 mkfs.vfat mkfs.fat blkid lsblk e2fsck resize2fs mount umount sgdisk rsync cryptsetup growpart sfdisk gawk awk
+    inst_check_multiple sync udevadm mkfs.ext2 mkfs.ext3 mkfs.ext4 mkfs.vfat mkfs.fat blkid lsblk e2fsck resize2fs mount umount sgdisk rsync cryptsetup gawk awk
 
     # Install libraries needed by gawk
     inst_libdir_file "libsigsegv.so*"

--- a/pkg/values/packagemaps.go
+++ b/pkg/values/packagemaps.go
@@ -41,7 +41,6 @@ var CommonPackages = []string{
 	"jq",         // No idea why we need it, check if we can drop it?
 	"dosfstools", // For the fat32 partition on EFI systems
 	"e2fsprogs",  // mkfs support for ext2/3/4
-	"parted",     // Partitioning support, check if we need it anymore
 	"logrotate",  // Log rotation support
 }
 
@@ -65,11 +64,10 @@ var ImmucorePackages = PackageMap{
 	DebianFamily: {
 		ArchCommon: {
 			Common: {
-				"dracut",            // To build the initrd
-				"dracut-network",    // Network-legacy support for dracut
-				"isc-dhcp-common",   // Network-legacy support for dracut, basic tools
-				"isc-dhcp-client",   // Network-legacy support for dracut, basic tools
-				"cloud-guest-utils", // This brings growpart, so we can resize the partitions
+				"dracut",          // To build the initrd
+				"dracut-network",  // Network-legacy support for dracut
+				"isc-dhcp-common", // Network-legacy support for dracut, basic tools
+				"isc-dhcp-client", // Network-legacy support for dracut, basic tools
 			},
 		},
 	},
@@ -290,7 +288,6 @@ var BasePackages = PackageMap{
 				"device-mapper",
 				"fail2ban", // Basic security tool
 				"findutils",
-				"growpart",
 				"gptfdisk",
 				"haveged",
 				"htop",
@@ -351,7 +348,6 @@ var BasePackages = PackageMap{
 				"bash",
 				"bash-completion",
 				"blkid",
-				"cloud-utils-growpart",
 				"bonding",
 				"bridge",
 				"busybox-openrc",
@@ -428,7 +424,6 @@ var BasePackages = PackageMap{
 				"gdisk",                   // Yip requires it for partitioning, maybe BasePackages
 				"audit",                   // For audit support, check if needed?
 				"cracklib-dicts",          // Password dictionary support
-				"cloud-utils-growpart",    // grow partition use. Check if yip still needs it?
 				"device-mapper",           // Device mapper support, needed for lvm and cryptsetup
 				"device-mapper-multipath", // For multipath support, needed for dracut
 				"iproute",                 // Basic tool for networking
@@ -467,10 +462,8 @@ var BasePackages = PackageMap{
 		ArchCommon: {
 			Common: {
 				// TODO: Check if we need all of these packages, some of them are probably not needed or can go into the family?
-				"fdisk", // Yip requires it for partitioning
 				"conntrack",
-				"console-data",      // Console font support
-				"cloud-guest-utils", // Yip requires it, this brings growpart, so we can resize the partitions
+				"console-data", // Console font support
 				"gettext",
 				"systemd-container",      // Not sure if needed?
 				"ubuntu-advantage-tools", // For ubuntu advantage support, enablement of ubuntu services

--- a/pkg/values/packagemaps.go
+++ b/pkg/values/packagemaps.go
@@ -234,7 +234,6 @@ var BasePackages = PackageMap{
 				"ethtool",
 				"fuse3",
 				"fail2ban", // Basic security tool
-				"gdisk",
 				"gnupg",
 				"gnupg1-l10n",
 				"haveged",
@@ -288,7 +287,6 @@ var BasePackages = PackageMap{
 				"device-mapper",
 				"fail2ban", // Basic security tool
 				"findutils",
-				"gptfdisk",
 				"haveged",
 				"htop",
 				"iproute2",
@@ -402,7 +400,6 @@ var BasePackages = PackageMap{
 				"procps",
 				"qemu-guest-agent",
 				"rbd-nbd",
-				"sgdisk",
 				"smartmontools",
 				"squashfs-tools",
 				"strace",
@@ -421,7 +418,6 @@ var BasePackages = PackageMap{
 	RedHatFamily: {
 		ArchCommon: {
 			Common: {
-				"gdisk",                   // Yip requires it for partitioning, maybe BasePackages
 				"audit",                   // For audit support, check if needed?
 				"cracklib-dicts",          // Password dictionary support
 				"device-mapper",           // Device mapper support, needed for lvm and cryptsetup


### PR DESCRIPTION
We discovered that several binaries are no longer a hard requirement for immucore to work.

- Removed 'growpart', 'parted', 'fdisk' (???) and 'partprobe', from the immucore.files list and the dracut needed binaries
- Streamlined the bundled.go installation check by eliminating redundant binaries
- This change reduces the footprint of the immucore package and simplifies the installation process.
- Updating to the new yip also provides a pure go layout package which doesnt need as many binaries in the initramfs

requires https://github.com/mudler/yip/pull/240
requires https://github.com/kairos-io/immucore/pull/518
requires https://github.com/kairos-io/kairos-agent/pull/1045