### PR TITLE
fix: Update UPX and agent/imucore versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /app
 # Copy the Makefile first to leverage Docker cache
 COPY Makefile .
 RUN apt-get update && apt-get install -y --no-install-recommends xz-utils file && \
-  curl -Ls https://github.com/upx/upx/releases/download/v5.0.0/upx-5.0.0-${TARGETARCH}_linux.tar.xz -o - | tar xvJf - -C /tmp && \
-  cp /tmp/upx-5.0.0-${TARGETARCH}_linux/upx /usr/local/bin/ && \
+  curl -Ls https://github.com/upx/upx/releases/download/v5.0.2/upx-5.0.2-${TARGETARCH}_linux.tar.xz -o - | tar xvJf - -C /tmp && \
+  cp /tmp/upx-5.0.2-${TARGETARCH}_linux/upx /usr/local/bin/ && \
   chmod +x /usr/local/bin/upx && \
   apt-get remove -y xz-utils && \
   rm -rf /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Variables
-AGENT_VERSION := v2.25.2
-IMMUCORE_VERSION := v0.11.4
+AGENT_VERSION := v2.26.0-beta3
+IMMUCORE_VERSION := v0.12.0-beta3
 KCRYPT_DISCOVERY_CHALLENGER_VERSION := v0.11.4
 PROVIDER_KAIROS_VERSION := v2.14.0
 EDGEVPN_VERSION := v0.31.1
@@ -73,8 +73,8 @@ $(OUTPUT_DIR_FIPS)/%-fips:
 compress:
 	@if [ -z "$(SKIP_UPX)" ]; then \
 		echo "Running upx compress..."; \
-		upx -q -5 $(addprefix $(OUTPUT_DIR)/, $(BINARY_NAMES) edgevpn ); \
-		upx -q -5 $(addprefix $(OUTPUT_DIR_FIPS)/, $(BINARY_NAMES)); \
+		upx -q --best --lzma $(addprefix $(OUTPUT_DIR)/, $(BINARY_NAMES) edgevpn ); \
+		upx -q --best --lzma $(addprefix $(OUTPUT_DIR_FIPS)/, $(BINARY_NAMES)); \
 	else \
 		echo "Skipping upx compression as SKIP_UPX is set"; \
 	fi


### PR DESCRIPTION
- Updated UPX version from 5.0.0 to 5.0.2 for improved performance and bug fixes.
- Increase compression from -5 to --best with --lzma as recommended in the upx docs for releases
- Bumped AGENT_VERSION from v2.25.2 to v2.26.0-beta3.
- Bumped IMMUCORE_VERSION from v0.11.4 to v0.12.0-beta3.