### PR TITLE
fix: Correct package name for systemd network service

### DIFF
--- a/pkg/values/packagemaps.go
+++ b/pkg/values/packagemaps.go
@@ -333,13 +333,6 @@ var BasePackages = PackageMap{
 			},
 		},
 	},
-	OpenSUSETumbleweed: {
-		ArchCommon: {
-			Common: {
-				"systemd-resolved",
-			},
-		},
-	},
 	AlpineFamily: {
 		ArchCommon: {
 			Common: {

--- a/pkg/values/packagemaps.go
+++ b/pkg/values/packagemaps.go
@@ -306,6 +306,7 @@ var BasePackages = PackageMap{
 				"strace",
 				"systemd",
 				"systemd-networkd",
+				"systemd-resolved",
 				"timezone",
 				"tmux",
 				"vim",

--- a/pkg/values/packagemaps.go
+++ b/pkg/values/packagemaps.go
@@ -305,7 +305,7 @@ var BasePackages = PackageMap{
 				"qemu-guest-agent", // TODO: Move this to generic model?
 				"strace",
 				"systemd",
-				"systemd-network",
+				"systemd-networkd",
 				"timezone",
 				"tmux",
 				"vim",


### PR DESCRIPTION
- Changed `systemd-network` to `systemd-networkd` for accuracy
- Ensures consistency with the actual service name used in the system
Fixes https://github.com/kairos-io/kairos/issues/3781


https://www.suse.com/support/update/announcement/2025/suse-ru-20254138-2/