### PR TITLE
fix: Update hosts configuration for persistent files

### DIFF
--- a/pkg/bundled/cloudconfigs/31_hosts.yaml
+++ b/pkg/bundled/cloudconfigs/31_hosts.yaml
@@ -10,7 +10,7 @@
 ## We should run the hosts part before the hostname, as yip will try to update the hosts file when changing the hostname
 ## so we get the proper name added to the hosts file
 stages:
-  initramfs.before:
+  initramfs:
     - if: '[ ! -f "/run/cos/recovery_mode" ] && [ ! -L "/etc/hosts" ]'
       name: "Ensure persistent hosts file"
       directories:
@@ -29,13 +29,16 @@ stages:
       commands:
         - rm -f /etc/hosts
         - ln -sf /usr/local/etc/hosts /etc/hosts
-    - if: '[ ! -f "/run/cos/recovery_mode" ] && [ ! -L "/etc/hostname" ]'
-      name: "Ensure persistent hostname"
+    - if: '[ ! -f "/run/cos/recovery_mode" ] && [ ! -d /usr/local/etc ]' # check that /usr/local/etc doesnt not exist already
+      name: "Ensure persistent /etc/ directory"
       directories:
         - path: "/usr/local/etc/"
           permissions: 0600
           owner: 0
           group: 0
+    # Check that hostname is not already a symlink and the persistent file does not exist
+    - if: '[ ! -f "/run/cos/recovery_mode" ] && [ ! -L "/etc/hostname" ]'
+      name: "Ensure persistent hostname"
       files:
         - path: "/usr/local/etc/hostname"
           permissions: 0644


### PR DESCRIPTION
- Changed stage from `initramfs.before` to `initramfs` for proper execution order.
- Added check to ensure `/usr/local/etc` directory does not exist before creating it.
- Ensured persistent hostname only if it is not already a symlink and the persistent file does not exist.


(cherry picked from commit d8d38a2e26ecd631a4c845ff88a17af90e7a3025)