### PR TITLE
fix: Update permissions for persistent hosts directory

### DIFF
--- a/pkg/bundled/cloudconfigs/31_hosts.yaml
+++ b/pkg/bundled/cloudconfigs/31_hosts.yaml
@@ -15,7 +15,7 @@ stages:
       name: "Ensure persistent hosts file"
       directories:
         - path: "/usr/local/etc/"
-          permissions: 0600
+          permissions: 0755
           owner: 0
           group: 0
       files:

--- a/pkg/bundled/cloudconfigs/31_hosts.yaml
+++ b/pkg/bundled/cloudconfigs/31_hosts.yaml
@@ -33,7 +33,7 @@ stages:
       name: "Ensure persistent /etc/ directory"
       directories:
         - path: "/usr/local/etc/"
-          permissions: 0600
+          permissions: 0755
           owner: 0
           group: 0
     # Check that hostname is not already a symlink and the persistent file does not exist


### PR DESCRIPTION
- Changed permissions from `0600` to `0755` for the `/usr/local/etc/` directory
- This change allows read and execute access for all users, facilitating better access for necessary services