### PR TITLE
feat: Restore mkfs binaries to initramfs

### DIFF
--- a/pkg/bundled/alpineInit/immucore.files
+++ b/pkg/bundled/alpineInit/immucore.files
@@ -9,6 +9,7 @@
 /sbin/e2fsck
 /sbin/openrc
 /sbin/openrc-run
+/sbin/mkfs.*
 /etc/udev/*
 /lib/udev/*
 /usr/lib/udev/*

--- a/pkg/bundled/bundled.go
+++ b/pkg/bundled/bundled.go
@@ -240,7 +240,7 @@ install() {
 
     inst_check_multiple immucore kairos-agent
     # add utils used by yip stages
-    inst_check_multiple sync udevadm blkid lsblk e2fsck mount umount rsync cryptsetup gawk awk
+    inst_check_multiple sync udevadm blkid lsblk e2fsck mount umount rsync cryptsetup gawk awk mkfs.ext2 mkfs.ext3 mkfs.ext4 mkfs.vfat mkfs.fat
 
     # Install libraries needed by gawk
     inst_libdir_file "libsigsegv.so*"


### PR DESCRIPTION
- Added mkfs.ext2, mkfs.ext3, mkfs.ext4, mkfs.vfat, and mkfs.fat to the initramfs installation process
- Ensures filesystem creation utilities are available during initialization