### PR TITLE
fix: Remove mkfs.vfat from initramfs installation

### DIFF
--- a/pkg/bundled/bundled.go
+++ b/pkg/bundled/bundled.go
@@ -240,7 +240,7 @@ install() {
 
     inst_check_multiple immucore kairos-agent
     # add utils used by yip stages
-    inst_check_multiple sync udevadm blkid lsblk e2fsck mount umount rsync cryptsetup gawk awk mkfs.ext2 mkfs.ext3 mkfs.ext4 mkfs.vfat mkfs.fat
+    inst_check_multiple sync udevadm blkid lsblk e2fsck mount umount rsync cryptsetup gawk awk mkfs.ext2 mkfs.ext3 mkfs.ext4 mkfs.fat
 
     # Install libraries needed by gawk
     inst_libdir_file "libsigsegv.so*"


### PR DESCRIPTION
- Removed `mkfs.vfat` from the list of installed utilities in the initramfs configuration.
- Use mkfs.fat instead as they are both the same binary