### PR TITLE
feat: Add RISC-V build

### DIFF
--- a/.github/workflows/test-riscv.yml
+++ b/.github/workflows/test-riscv.yml
@@ -40,9 +40,4 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ matrix.base_image }}
             VALIDATE_IMAGE=${{ matrix.base_image }}
-            PROVIDER_NAME=
-            PROVIDER_VERSION=
             VERSION=${{ env.VERSION }}
-            FIPS=false
-            TRUSTED_BOOT=false
-            MODEL=generic

--- a/.github/workflows/test-riscv.yml
+++ b/.github/workflows/test-riscv.yml
@@ -19,10 +19,10 @@ jobs:
       matrix:
         base_image:
           # Working images
-          - "riscv64/ubuntu:24.04"
-          - "riscv64/ubuntu:26.04"
-          - "riscv64/debian:trixie"
-          - "fedorariscv/base:latest"
+          # - "riscv64/ubuntu:24.04"
+          # - "riscv64/debian:trixie"
+          # - "fedorariscv/base:latest"
+          - "ttl.sh/hadron-riscv64-cloud:f659c0204c72cd4ee5c7febd1c779c595b97789e"
           # TODO: Rocky Linux 10 - fails because epel-release package is not available for RISC-V
           # kairos-init tries to install epel-release which doesn't exist in Rocky's RISC-V repos
           # - "rockylinux/rockylinux:10"

--- a/.github/workflows/test-riscv.yml
+++ b/.github/workflows/test-riscv.yml
@@ -33,12 +33,13 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: Dockerfile.test
+          file: Dockerfile.test.riscv
           platforms: linux/riscv64
           push: false
           tags: kairos-${{ matrix.base_image }}
           build-args: |
             BASE_IMAGE=${{ matrix.base_image }}
+            VALIDATE_IMAGE=${{ matrix.base_image }}
             PROVIDER_NAME=
             PROVIDER_VERSION=
             VERSION=${{ env.VERSION }}

--- a/.github/workflows/test-riscv.yml
+++ b/.github/workflows/test-riscv.yml
@@ -18,9 +18,18 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - "rockylinux/rockylinux:10"
-          - "riscv64/debian:sid"
-          - "registry.opensuse.org/opensuse/tumbleweed"
+          # Working images
+          - "riscv64/ubuntu:24.04"
+          - "riscv64/ubuntu:26.04"
+          - "riscv64/debian:trixie"
+          - "fedorariscv/base:latest"
+          # TODO: Rocky Linux 10 - fails because epel-release package is not available for RISC-V
+          # kairos-init tries to install epel-release which doesn't exist in Rocky's RISC-V repos
+          # - "rockylinux/rockylinux:10"
+          # TODO: openSUSE Tumbleweed - fails because some packages are not available for RISC-V:
+          # shim, open-vm-tools, and possibly others from the zypper install command
+          # - "registry.opensuse.org/opensuse/tumbleweed"
+          # NOTE: openSUSE Leap does not have official RISC-V images
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test-riscv.yml
+++ b/.github/workflows/test-riscv.yml
@@ -1,0 +1,47 @@
+name: Tests (RISC-V)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 'main'
+
+concurrency:
+  group: build-image-riscv-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  cancel-in-progress: true
+
+jobs:
+  testing_build_matrix:
+    name: riscv64 - ${{ matrix.base_image }}
+    runs-on: ubuntu-24.04-riscv
+    strategy:
+      fail-fast: false
+      matrix:
+        base_image:
+          - "rockylinux/rockylinux:9"
+          - "debian:sid"
+          - "opensuse/tumbleweed"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get version for docker build
+        run: echo "VERSION=$(git describe --tags --dirty)" >> $GITHUB_ENV
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Build the docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.test
+          platforms: linux/riscv64
+          push: false
+          tags: kairos-${{ matrix.base_image }}
+          build-args: |
+            BASE_IMAGE=${{ matrix.base_image }}
+            PROVIDER_NAME=
+            PROVIDER_VERSION=
+            VERSION=${{ env.VERSION }}
+            FIPS=false
+            TRUSTED_BOOT=false
+            MODEL=generic

--- a/.github/workflows/test-riscv.yml
+++ b/.github/workflows/test-riscv.yml
@@ -21,7 +21,7 @@ jobs:
           # Working images
           # - "riscv64/ubuntu:24.04"
           # - "riscv64/debian:trixie"
-          # - "fedorariscv/base:latest"
+          - "fedorariscv/base:latest"
           - "ttl.sh/hadron-riscv64-cloud:f659c0204c72cd4ee5c7febd1c779c595b97789e"
           # TODO: Rocky Linux 10 - fails because epel-release package is not available for RISC-V
           # kairos-init tries to install epel-release which doesn't exist in Rocky's RISC-V repos

--- a/.github/workflows/test-riscv.yml
+++ b/.github/workflows/test-riscv.yml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - "rockylinux/rockylinux:9"
-          - "debian:sid"
-          - "opensuse/tumbleweed"
+          - "rockylinux/rockylinux:10"
+          - "riscv64/debian:sid"
+          - "registry.opensuse.org/opensuse/tumbleweed"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Dockerfile.test.riscv
+++ b/Dockerfile.test.riscv
@@ -1,9 +1,10 @@
+# hadolint global ignore=DL3006
 ARG BASE_IMAGE=riscv64/debian:sid
 ARG VALIDATE_IMAGE=riscv64/debian:sid
 ARG VALIDATE=true
 
 # Build kairos dependencies from source for RISC-V
-FROM golang AS deps-builder
+FROM golang:1.24 AS deps-builder
 ARG AGENT_VERSION=v2.27.1
 ARG IMMUCORE_VERSION=v0.13.2
 ARG KCRYPT_VERSION=v0.12.2
@@ -17,47 +18,49 @@ ENV GOARCH=riscv64
 WORKDIR /build
 
 # Build kairos-agent
-RUN git clone --depth 1 --branch ${AGENT_VERSION} https://github.com/kairos-io/kairos-agent.git && \
-    cd kairos-agent && \
-    go build -o /out/kairos-agent .
+RUN git clone --depth 1 --branch ${AGENT_VERSION} https://github.com/kairos-io/kairos-agent.git
+WORKDIR /build/kairos-agent
+RUN go build -o /out/kairos-agent .
 
 # Build immucore (temporarily using fork for RISC-V support)
 # TODO: restore --branch ${IMMUCORE_VERSION} and switch back to kairos-io/immucore once RISC-V support is merged upstream
-RUN git clone --depth 1 https://github.com/mauromorales/immucore.git && \
-    cd immucore && \
-    go build -o /out/immucore .
+WORKDIR /build
+RUN git clone --depth 1 https://github.com/mauromorales/immucore.git
+WORKDIR /build/immucore
+RUN go build -o /out/immucore .
 
 # Build kcrypt-discovery-challenger
-RUN git clone --depth 1 --branch ${KCRYPT_VERSION} https://github.com/kairos-io/kcrypt-discovery-challenger.git && \
-    cd kcrypt-discovery-challenger && \
-    go build -o /out/kcrypt-discovery-challenger .
+WORKDIR /build
+RUN git clone --depth 1 --branch ${KCRYPT_VERSION} https://github.com/kairos-io/kcrypt-discovery-challenger.git
+WORKDIR /build/kcrypt-discovery-challenger
+RUN go build -o /out/kcrypt-discovery-challenger .
 
 # Build provider-kairos
-RUN git clone --depth 1 --branch ${PROVIDER_VERSION} https://github.com/kairos-io/provider-kairos.git && \
-    cd provider-kairos && \
-    go build -o /out/provider-kairos .
+WORKDIR /build
+RUN git clone --depth 1 --branch ${PROVIDER_VERSION} https://github.com/kairos-io/provider-kairos.git
+WORKDIR /build/provider-kairos
+RUN go build -o /out/provider-kairos .
 
 # Build edgevpn
-RUN git clone --depth 1 --branch ${EDGEVPN_VERSION} https://github.com/mudler/edgevpn.git && \
-    cd edgevpn && \
-    go build -o /out/edgevpn .
+WORKDIR /build
+RUN git clone --depth 1 --branch ${EDGEVPN_VERSION} https://github.com/mudler/edgevpn.git
+WORKDIR /build/edgevpn
+RUN go build -o /out/edgevpn .
 
-# Create version-info.yaml
+# Create version-info.yaml and placeholder FIPS binaries
 RUN echo "kairos-agent: ${AGENT_VERSION}" > /out/version-info.yaml && \
     echo "immucore: ${IMMUCORE_VERSION}" >> /out/version-info.yaml && \
     echo "kcrypt-discovery-challenger: ${KCRYPT_VERSION}" >> /out/version-info.yaml && \
     echo "provider-kairos: ${PROVIDER_VERSION}" >> /out/version-info.yaml && \
-    echo "edgevpn: ${EDGEVPN_VERSION}" >> /out/version-info.yaml
-
-# Create placeholder FIPS binaries (FIPS not supported on RISC-V)
-RUN mkdir -p /out/fips && \
+    echo "edgevpn: ${EDGEVPN_VERSION}" >> /out/version-info.yaml && \
+    mkdir -p /out/fips && \
     cp /out/kairos-agent /out/fips/kairos-agent && \
     cp /out/immucore /out/fips/immucore && \
     cp /out/kcrypt-discovery-challenger /out/fips/kcrypt-discovery-challenger && \
     cp /out/provider-kairos /out/fips/provider-kairos
 
 
-FROM golang AS build
+FROM golang:1.24 AS build
 WORKDIR /app
 
 # Copy pre-built RISC-V binaries (including fips placeholders)
@@ -83,6 +86,6 @@ ARG VERSION=v0.0.1
 ARG VALIDATE=true
 
 COPY --from=kairos-init /kairos-init /kairos-init
-RUN /kairos-init -l debug --version "${VERSION}"
-RUN if [ "${VALIDATE}" = 'true' ]; then /kairos-init validate; fi
-RUN rm /kairos-init
+RUN /kairos-init -l debug --version "${VERSION}" && \
+    if [ "${VALIDATE}" = 'true' ]; then /kairos-init validate; fi && \
+    rm /kairos-init

--- a/Dockerfile.test.riscv
+++ b/Dockerfile.test.riscv
@@ -22,7 +22,8 @@ RUN git clone --depth 1 --branch ${AGENT_VERSION} https://github.com/kairos-io/k
     go build -o /out/kairos-agent .
 
 # Build immucore (temporarily using fork for RISC-V support)
-RUN git clone --depth 1 --branch ${IMMUCORE_VERSION} https://github.com/mauromorales/immucore.git && \
+# TODO: restore --branch ${IMMUCORE_VERSION} and switch back to kairos-io/immucore once RISC-V support is merged upstream
+RUN git clone --depth 1 https://github.com/mauromorales/immucore.git && \
     cd immucore && \
     go build -o /out/immucore .
 

--- a/Dockerfile.test.riscv
+++ b/Dockerfile.test.riscv
@@ -21,8 +21,8 @@ RUN git clone --depth 1 --branch ${AGENT_VERSION} https://github.com/kairos-io/k
     cd kairos-agent && \
     go build -o /out/kairos-agent .
 
-# Build immucore
-RUN git clone --depth 1 --branch ${IMMUCORE_VERSION} https://github.com/kairos-io/immucore.git && \
+# Build immucore (temporarily using fork for RISC-V support)
+RUN git clone --depth 1 --branch ${IMMUCORE_VERSION} https://github.com/mauromorales/immucore.git && \
     cd immucore && \
     go build -o /out/immucore .
 

--- a/Dockerfile.test.riscv
+++ b/Dockerfile.test.riscv
@@ -79,15 +79,10 @@ COPY --from=build /app/kairos-init /kairos-init
 RUN /kairos-init validate
 
 FROM ${BASE_IMAGE} AS default
-ARG MODEL=generic
-ARG TRUSTED_BOOT=false
-ARG PROVIDER_NAME
-ARG PROVIDER_VERSION
 ARG VERSION=v0.0.1
-ARG FIPS=false
-ARG VALIDATE
+ARG VALIDATE=true
 
 COPY --from=kairos-init /kairos-init /kairos-init
-RUN /kairos-init -l debug -m "${MODEL}" -t "${TRUSTED_BOOT}" --provider "${PROVIDER_NAME}" --provider-"${PROVIDER_NAME}"-version "${PROVIDER_VERSION}" --version "${VERSION}" "$(if [ "${FIPS}" = "true" ]; then echo "--fips"; fi)"
-RUN if [ "${VALIDATE}" = 'true' ];then /kairos-init validate -t "${TRUSTED_BOOT}"; fi
+RUN /kairos-init -l debug --version "${VERSION}"
+RUN if [ "${VALIDATE}" = 'true' ]; then /kairos-init validate; fi
 RUN rm /kairos-init

--- a/Dockerfile.test.riscv
+++ b/Dockerfile.test.riscv
@@ -1,0 +1,92 @@
+ARG BASE_IMAGE=riscv64/debian:sid
+ARG VALIDATE_IMAGE=riscv64/debian:sid
+ARG VALIDATE=true
+
+# Build kairos dependencies from source for RISC-V
+FROM golang AS deps-builder
+ARG AGENT_VERSION=v2.27.1
+ARG IMMUCORE_VERSION=v0.13.2
+ARG KCRYPT_VERSION=v0.12.2
+ARG PROVIDER_VERSION=v2.14.2
+ARG EDGEVPN_VERSION=v0.31.1
+
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=riscv64
+
+WORKDIR /build
+
+# Build kairos-agent
+RUN git clone --depth 1 --branch ${AGENT_VERSION} https://github.com/kairos-io/kairos-agent.git && \
+    cd kairos-agent && \
+    go build -o /out/kairos-agent .
+
+# Build immucore
+RUN git clone --depth 1 --branch ${IMMUCORE_VERSION} https://github.com/kairos-io/immucore.git && \
+    cd immucore && \
+    go build -o /out/immucore .
+
+# Build kcrypt-discovery-challenger
+RUN git clone --depth 1 --branch ${KCRYPT_VERSION} https://github.com/kairos-io/kcrypt-discovery-challenger.git && \
+    cd kcrypt-discovery-challenger && \
+    go build -o /out/kcrypt-discovery-challenger .
+
+# Build provider-kairos
+RUN git clone --depth 1 --branch ${PROVIDER_VERSION} https://github.com/kairos-io/provider-kairos.git && \
+    cd provider-kairos && \
+    go build -o /out/provider-kairos .
+
+# Build edgevpn
+RUN git clone --depth 1 --branch ${EDGEVPN_VERSION} https://github.com/mudler/edgevpn.git && \
+    cd edgevpn && \
+    go build -o /out/edgevpn .
+
+# Create version-info.yaml
+RUN echo "kairos-agent: ${AGENT_VERSION}" > /out/version-info.yaml && \
+    echo "immucore: ${IMMUCORE_VERSION}" >> /out/version-info.yaml && \
+    echo "kcrypt-discovery-challenger: ${KCRYPT_VERSION}" >> /out/version-info.yaml && \
+    echo "provider-kairos: ${PROVIDER_VERSION}" >> /out/version-info.yaml && \
+    echo "edgevpn: ${EDGEVPN_VERSION}" >> /out/version-info.yaml
+
+# Create placeholder FIPS binaries (FIPS not supported on RISC-V)
+RUN mkdir -p /out/fips && \
+    cp /out/kairos-agent /out/fips/kairos-agent && \
+    cp /out/immucore /out/fips/immucore && \
+    cp /out/kcrypt-discovery-challenger /out/fips/kcrypt-discovery-challenger && \
+    cp /out/provider-kairos /out/fips/provider-kairos
+
+
+FROM golang AS build
+WORKDIR /app
+
+# Copy pre-built RISC-V binaries (including fips placeholders)
+COPY --from=deps-builder /out/ /app/pkg/bundled/binaries/
+
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ENV CGO_ENABLED=0
+RUN go build -o /app/kairos-init .
+
+
+FROM scratch AS kairos-init
+COPY --from=build /app/kairos-init /kairos-init
+
+# Target to use the validator directly inside a generated image with kairos-init
+FROM ${VALIDATE_IMAGE} AS validate
+COPY --from=build /app/kairos-init /kairos-init
+RUN /kairos-init validate
+
+FROM ${BASE_IMAGE} AS default
+ARG MODEL=generic
+ARG TRUSTED_BOOT=false
+ARG PROVIDER_NAME
+ARG PROVIDER_VERSION
+ARG VERSION=v0.0.1
+ARG FIPS=false
+ARG VALIDATE
+
+COPY --from=kairos-init /kairos-init /kairos-init
+RUN /kairos-init -l debug -m "${MODEL}" -t "${TRUSTED_BOOT}" --provider "${PROVIDER_NAME}" --provider-"${PROVIDER_NAME}"-version "${PROVIDER_VERSION}" --version "${VERSION}" "$(if [ "${FIPS}" = "true" ]; then echo "--fips"; fi)"
+RUN if [ "${VALIDATE}" = 'true' ];then /kairos-init validate -t "${TRUSTED_BOOT}"; fi
+RUN rm /kairos-init

--- a/Dockerfile.test.riscv
+++ b/Dockerfile.test.riscv
@@ -4,7 +4,7 @@ ARG VALIDATE_IMAGE=riscv64/debian:sid
 ARG VALIDATE=true
 
 # Build kairos dependencies from source for RISC-V
-FROM golang:1.24 AS deps-builder
+FROM golang:1.26 AS deps-builder
 ARG AGENT_VERSION=v2.27.1
 ARG IMMUCORE_VERSION=v0.13.2
 ARG KCRYPT_VERSION=v0.12.2
@@ -60,7 +60,7 @@ RUN echo "kairos-agent: ${AGENT_VERSION}" > /out/version-info.yaml && \
     cp /out/provider-kairos /out/fips/provider-kairos
 
 
-FROM golang:1.24 AS build
+FROM golang:1.26 AS build
 WORKDIR /app
 
 # Copy pre-built RISC-V binaries (including fips placeholders)

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -46,6 +46,8 @@ func DetectSystem(l logger.KairosLogger) values.System {
 		s.Arch = values.ArchAMD64
 	case values.ArchARM64:
 		s.Arch = values.ArchARM64
+	case values.ArchRISCV64:
+		s.Arch = values.ArchRISCV64
 	}
 
 	// Store the version

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -14,9 +14,10 @@ func (a Architecture) String() string {
 }
 
 const (
-	ArchAMD64  Architecture = "amd64"
-	ArchARM64  Architecture = "arm64"
-	ArchCommon Architecture = "common"
+	ArchAMD64   Architecture = "amd64"
+	ArchARM64   Architecture = "arm64"
+	ArchRISCV64 Architecture = "riscv64"
+	ArchCommon  Architecture = "common"
 )
 
 type Distro string


### PR DESCRIPTION
Use RISE RISC-V Runners (ubuntu-24.04-riscv) to build and test kairos-init on native riscv64 hardware with RockyLinux 9, Debian sid, and openSUSE Tumbleweed base images.

Made-with: Cursor