### PR TITLE
fix: Add Oracle Linux to the RHEL-family like OnlyifOS and only_os regexes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,8 @@ jobs:
          - "rockylinux/rockylinux:10"
          - "almalinux:9"
          - "almalinux:10"
+         - "oraclelinux:9"
+         - "oraclelinux:10"
          - "quay.io/centos/centos:stream9"
          - "quay.io/centos/centos:stream10"
          - "ghcr.io/kairos-io/hadron:v0.0.1-beta6"

--- a/pkg/bundled/cloudconfigs/01_extra_binds.yaml
+++ b/pkg/bundled/cloudconfigs/01_extra_binds.yaml
@@ -14,7 +14,7 @@ stages:
           /var/snap
           /var/lib/snapd
     - if: '[ ! -f "/run/cos/recovery_mode" ] && [ ! -e "/run/cos/uki_install_mode" ] && [ ! -e "/run/cos/autoreset_mode" ]'
-      only_os: "Red.*Hat.*|CentOS.*|Fedora.*|Rocky.*|AlmaLinux.*|SLES.*|[Oo]penSUSE.*|SUSE.*"
+      only_os: "Red.*Hat.*|CentOS.*|Fedora.*|Rocky.*|AlmaLinux.*|Oracle.*Linux.*|SLES.*|[Oo]penSUSE.*|SUSE.*"
       name: "Extra layout configuration for active/passive mode"
       environment_file: /run/cos/extra-layout.env
       environment:

--- a/pkg/bundled/cloudconfigs/05_network.yaml
+++ b/pkg/bundled/cloudconfigs/05_network.yaml
@@ -3,7 +3,7 @@ stages:
   rootfs.before:
     - name: "Enable systemd-network config files for DHCP"  # Needed if systemd-networkd runs in the initramfs!
       only_service_manager: "systemd"
-      only_os: "Ubuntu.*|Debian.*|Fedora.*|CentOS.*|Rocky.*|AlmaLinux.*|SUSE.*|[Oo]penSUSE.*|Hadron.*|Red.*Hat.*"
+      only_os: "Ubuntu.*|Debian.*|Fedora.*|CentOS.*|Rocky.*|AlmaLinux.*|Oracle.*Linux.*|SUSE.*|[Oo]penSUSE.*|Hadron.*|Red.*Hat.*"
       directories:
         - path: "/etc/systemd/network"  # doesnt exist on initramfs
           permissions: 0775
@@ -35,7 +35,7 @@ stages:
   initramfs:
     - name: "Enable systemd-network config files for DHCP"
       only_service_manager: "systemd"
-      only_os: "Ubuntu.*|Debian.*|Fedora.*|CentOS.*|Rocky.*|AlmaLinux.*|SUSE.*|[Oo]penSUSE.*|Hadron.*|Red.*Hat.*"
+      only_os: "Ubuntu.*|Debian.*|Fedora.*|CentOS.*|Rocky.*|AlmaLinux.*|Oracle.*Linux.*|SUSE.*|[Oo]penSUSE.*|Hadron.*|Red.*Hat.*"
       files:
         - path: /etc/systemd/network/20-dhcp.network
           permissions: 0644

--- a/pkg/stages/steps_init.go
+++ b/pkg/stages/steps_init.go
@@ -59,7 +59,7 @@ func GetInitrdStage(_ values.System, logger logger.KairosLogger) ([]schema.Stage
 		stage = append(stage, []schema.Stage{
 			{
 				Name:     "Create new initrd",
-				OnlyIfOs: "Ubuntu.*|Debian.*|Fedora.*|CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*|SLES.*|[Oo]penSUSE.*|SUSE.*|Hadron.*",
+				OnlyIfOs: "Ubuntu.*|Debian.*|Fedora.*|CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*|Oracle\\sLinux.*|SLES.*|[Oo]penSUSE.*|SUSE.*|Hadron.*",
 				Commands: []string{
 					fmt.Sprintf("depmod -a %s", kernel),
 					dracutCmd,
@@ -341,7 +341,7 @@ func GetCleanupStage(_ values.System, l logger.KairosLogger) []schema.Stage {
 		},
 		{
 			Name:     "Cleanup",
-			OnlyIfOs: "Fedora.*|CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*",
+			OnlyIfOs: "Fedora.*|CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*|Oracle\\sLinux.*",
 			Commands: []string{
 				"dnf clean all",
 				"rm -rf /var/cache/dnf/* /tmp/* /var/tmp/*",
@@ -394,7 +394,7 @@ func GetServicesStage(_ values.System, l logger.KairosLogger) []schema.Stage {
 			Name:                 "Enable fail2ban service for RHEL family",
 			OnlyIfServiceManager: "systemd",
 			If:                   "test -f /usr/bin/fail2ban-server",
-			OnlyIfOs:             "CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*",
+			OnlyIfOs:             "CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*|Oracle\\sLinux.*",
 			Systemctl: schema.Systemctl{
 				Enable: []string{
 					"fail2ban",
@@ -424,7 +424,7 @@ func GetServicesStage(_ values.System, l logger.KairosLogger) []schema.Stage {
 		{
 			Name:                 "Enable chronyd service for RHEL family and Fedora",
 			OnlyIfServiceManager: "systemd",
-			OnlyIfOs:             "Fedora.*|CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*",
+			OnlyIfOs:             "Fedora.*|CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*|Oracle\\sLinux.*",
 			Systemctl: schema.Systemctl{
 				Enable: []string{
 					"chronyd",
@@ -491,7 +491,7 @@ func GetServicesStage(_ values.System, l logger.KairosLogger) []schema.Stage {
 		},
 		{
 			Name:                 "Enable services for RHEL family",
-			OnlyIfOs:             "Fedora.*|CentOS.*|Rocky.*|AlmaLinux.*",
+			OnlyIfOs:             "Fedora.*|CentOS.*|Rocky.*|AlmaLinux.*|Oracle\\sLinux.*",
 			OnlyIfServiceManager: "systemd",
 			Commands: []string{
 				"systemctl unmask getty.target",   // Unmask getty.target to allow login on ttys as it comes masked by default
@@ -958,7 +958,7 @@ func GetKairosInitramfsFilesStage(sis values.System, l logger.KairosLogger) ([]s
 		data = append(data, []schema.Stage{
 			{
 				Name:     "Add pmem modules to initramfs",
-				OnlyIfOs: "Ubuntu.*|Debian.*|Fedora.*|CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*|[Oo]penSUSE.*|SUSE.*",
+				OnlyIfOs: "Ubuntu.*|Debian.*|Fedora.*|CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*|Oracle\\sLinux.*|[Oo]penSUSE.*|SUSE.*",
 				Files: []schema.File{
 					{
 						Path:        bundled.DracutPmemPath,
@@ -971,7 +971,7 @@ func GetKairosInitramfsFilesStage(sis values.System, l logger.KairosLogger) ([]s
 			},
 			{
 				Name:     "Add sysext module to initramfs",
-				OnlyIfOs: "Ubuntu.*|Debian.*|Fedora.*|CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*|[Oo]penSUSE.*|SUSE.*|Hadron.*",
+				OnlyIfOs: "Ubuntu.*|Debian.*|Fedora.*|CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*|Oracle\\sLinux.*|[Oo]penSUSE.*|SUSE.*|Hadron.*",
 				If:       strconv.FormatBool(sysextModule),
 				Files: []schema.File{
 					{
@@ -985,7 +985,7 @@ func GetKairosInitramfsFilesStage(sis values.System, l logger.KairosLogger) ([]s
 			},
 			{
 				Name:     "Add network module to initramfs",
-				OnlyIfOs: "Ubuntu.*|Debian.*|Fedora.*|CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*|[Oo]penSUSE.*|SUSE.*|Hadron.*",
+				OnlyIfOs: "Ubuntu.*|Debian.*|Fedora.*|CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*|Oracle\\sLinux.*|[Oo]penSUSE.*|SUSE.*|Hadron.*",
 				Files: []schema.File{
 					{
 						Path:        bundled.DracutNetworkPath,
@@ -998,7 +998,7 @@ func GetKairosInitramfsFilesStage(sis values.System, l logger.KairosLogger) ([]s
 			},
 			{
 				Name:     "Add immucore module to initramfs",
-				OnlyIfOs: "Ubuntu.*|Debian.*|Fedora.*|CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*|[Oo]penSUSE.*|SUSE.*|Hadron.*",
+				OnlyIfOs: "Ubuntu.*|Debian.*|Fedora.*|CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*|Oracle\\sLinux.*|[Oo]penSUSE.*|SUSE.*|Hadron.*",
 				Files: []schema.File{
 					{
 						Path:        bundled.DracutConfigPath,
@@ -1051,7 +1051,7 @@ func GetKairosInitramfsFilesStage(sis values.System, l logger.KairosLogger) ([]s
 			},
 			{
 				Name:     "Add Multipath module to initramfs",
-				OnlyIfOs: "Debian.*|Fedora.*|CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*|[Oo]penSUSE.*|SUSE.*|Hadron.*",
+				OnlyIfOs: "Debian.*|Fedora.*|CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*|Oracle\\sLinux.*|[Oo]penSUSE.*|SUSE.*|Hadron.*",
 				Files: []schema.File{
 					{
 						Path:        bundled.DracutMultipathPath,
@@ -1069,7 +1069,7 @@ func GetKairosInitramfsFilesStage(sis values.System, l logger.KairosLogger) ([]s
 			data = append(data, []schema.Stage{
 				{
 					Name:     "Add fips support to initramfs",
-					OnlyIfOs: "Debian.*|Fedora.*|CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*|[Oo]penSUSE.*|SUSE.*|Hadron.*",
+					OnlyIfOs: "Debian.*|Fedora.*|CentOS.*|Red\\sHat.*|Rocky.*|AlmaLinux.*|Oracle\\sLinux.*|[Oo]penSUSE.*|SUSE.*|Hadron.*",
 					Files: []schema.File{
 						{
 							Path:        bundled.DracutFipsPath,

--- a/pkg/stages/steps_install.go
+++ b/pkg/stages/steps_install.go
@@ -76,7 +76,7 @@ func GetInstallStage(sis values.System, logger logger.KairosLogger) ([]schema.St
 	stage := []schema.Stage{
 		{
 			Name:     "Install epel repository",
-			OnlyIfOs: "AlmaLinux.*|Rocky.*|CentOS.*",
+			OnlyIfOs: "AlmaLinux.*|Rocky.*|CentOS.*|Oracle\\sLinux.*",
 			Packages: schema.Packages{
 				Install: []string{"epel-release"},
 			},

--- a/pkg/stages/steps_install.go
+++ b/pkg/stages/steps_install.go
@@ -76,9 +76,18 @@ func GetInstallStage(sis values.System, logger logger.KairosLogger) ([]schema.St
 	stage := []schema.Stage{
 		{
 			Name:     "Install epel repository",
-			OnlyIfOs: "AlmaLinux.*|Rocky.*|CentOS.*|Oracle\\sLinux.*",
+			OnlyIfOs: "AlmaLinux.*|Rocky.*|CentOS.*",
 			Packages: schema.Packages{
 				Install: []string{"epel-release"},
+			},
+		},
+		{
+			Name:     "Install EPEL repository for Oracle Linux",
+			OnlyIfOs: "Oracle\\sLinux.*",
+			Packages: schema.Packages{
+				Install: []string{
+					fmt.Sprintf("oracle-epel-release-el%d", fullVersion.Segments()[0]),
+				},
 			},
 		},
 		{

--- a/pkg/stages/steps_install.go
+++ b/pkg/stages/steps_install.go
@@ -259,6 +259,15 @@ func GetInstallKernelStage(sis values.System, logger logger.KairosLogger) ([]sch
 
 	stage := []schema.Stage{
 		{
+			Name:            "Enable UEK Repository for Oracle Linux 10 on ARM64",
+			OnlyIfOs:        "Oracle\\sLinux.*",
+			OnlyIfOsVersion: "10\\..*",
+			OnlyIfArch:      "arm64",
+			Commands: []string{
+				"dnf config-manager --enable ol10_UEKR8",
+			},
+		},
+		{
 			Name: "Install kernel packages",
 			Packages: schema.Packages{
 				Install: finalMergedPkgs,

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -96,6 +96,8 @@ func detectFromID(id string) (values.Distro, values.Family) {
 		return values.RockyLinux, values.RedHatFamily
 	case values.AlmaLinux:
 		return values.AlmaLinux, values.RedHatFamily
+	case values.OracleLinux:
+		return values.OracleLinux, values.RedHatFamily
 	case values.RedHat:
 		return values.RedHat, values.RedHatFamily
 	case values.Arch:

--- a/pkg/system/system_test.go
+++ b/pkg/system/system_test.go
@@ -20,6 +20,7 @@ func TestDetectFromReleaseIDs(t *testing.T) {
 		{name: "ID fedora", id: "fedora", expectedDistro: values.Fedora, expectedFamily: values.RedHatFamily},
 		{name: "ID rocky", id: "rocky", expectedDistro: values.RockyLinux, expectedFamily: values.RedHatFamily},
 		{name: "ID almalinux", id: "almalinux", expectedDistro: values.AlmaLinux, expectedFamily: values.RedHatFamily},
+		{name: "ID ol", id: "ol", expectedDistro: values.OracleLinux, expectedFamily: values.RedHatFamily},
 		{name: "ID rhel", id: "rhel", expectedDistro: values.RedHat, expectedFamily: values.RedHatFamily},
 		{name: "ID arch", id: "arch", expectedDistro: values.Arch, expectedFamily: values.ArchFamily},
 		{name: "ID alpine", id: "alpine", expectedDistro: values.Alpine, expectedFamily: values.AlpineFamily},

--- a/pkg/values/packagemaps.go
+++ b/pkg/values/packagemaps.go
@@ -282,6 +282,22 @@ var KernelPackages = PackageMap{
 			},
 		},
 	},
+	OracleLinux: {
+		ArchAMD64: {
+			Common: {
+				"kernel",
+				"kernel-modules",
+				"kernel-modules-extra",
+			},
+		},
+		ArchARM64: {
+			Common: {
+				"kernel-uek",
+				"kernel-uek-modules",
+				"kernel-uek-modules-extra",
+			},
+		},
+	},
 	RedHatFamily: {
 		ArchCommon: {
 			Common: {
@@ -333,6 +349,22 @@ var KernelPackagesTrustedBoot = PackageMap{
 			Common: {
 				"linux-image-arm64",
 				"firmware-linux-free",
+			},
+		},
+	},
+	OracleLinux: {
+		ArchAMD64: {
+			Common: {
+				"kernel",
+				"kernel-modules",
+				"kernel-modules-extra",
+			},
+		},
+		ArchARM64: {
+			Common: {
+				"kernel-uek",
+				"kernel-uek-modules",
+				"kernel-uek-modules-extra",
 			},
 		},
 	},
@@ -1069,10 +1101,14 @@ func GetKernelPackages(s System, l logger.KairosLogger) ([]string, error) {
 	if config.DefaultConfig.TrustedBoot {
 		// Kernel packages by model
 		if config.DefaultConfig.Model == Generic.String() {
+			distroKernel := KernelPackagesTrustedBoot[s.Distro]
+			hasDistroOverride := distroKernel != nil && (distroKernel[ArchCommon] != nil || distroKernel[s.Arch] != nil)
 			filteredPackages = append(filteredPackages, KernelPackagesTrustedBoot[s.Distro][ArchCommon]) // Common kernel packages to both arches
-			filteredPackages = append(filteredPackages, KernelPackagesTrustedBoot[s.Family][ArchCommon]) // Common kernel packages to both arches by family
 			filteredPackages = append(filteredPackages, KernelPackagesTrustedBoot[s.Distro][s.Arch])     // Specific kernel packages for the arch
-			filteredPackages = append(filteredPackages, KernelPackagesTrustedBoot[s.Family][s.Arch])     // Specific kernel packages for the arch by family
+			if !hasDistroOverride {
+				filteredPackages = append(filteredPackages, KernelPackagesTrustedBoot[s.Family][ArchCommon]) // Common kernel packages to both arches by family
+				filteredPackages = append(filteredPackages, KernelPackagesTrustedBoot[s.Family][s.Arch])     // Specific kernel packages for the arch by family
+			}
 		} else {
 			// Get specific packages for the model
 			// TODO: No support for trusted boot on models yet, so this part is probably useless for now?
@@ -1083,10 +1119,14 @@ func GetKernelPackages(s System, l logger.KairosLogger) ([]string, error) {
 		}
 	} else {
 		if config.DefaultConfig.Model == Generic.String() {
+			distroKernel := KernelPackages[s.Distro]
+			hasDistroOverride := distroKernel != nil && (distroKernel[ArchCommon] != nil || distroKernel[s.Arch] != nil)
 			filteredPackages = append(filteredPackages, KernelPackages[s.Distro][ArchCommon]) // Common kernel packages to both arches
-			filteredPackages = append(filteredPackages, KernelPackages[s.Family][ArchCommon]) // Common kernel packages to both arches by family
 			filteredPackages = append(filteredPackages, KernelPackages[s.Distro][s.Arch])     // Specific kernel packages for the arch
-			filteredPackages = append(filteredPackages, KernelPackages[s.Family][s.Arch])     // Specific kernel packages for the arch by family
+			if !hasDistroOverride {
+				filteredPackages = append(filteredPackages, KernelPackages[s.Family][ArchCommon]) // Common kernel packages to both arches by family
+				filteredPackages = append(filteredPackages, KernelPackages[s.Family][s.Arch])     // Specific kernel packages for the arch by family
+			}
 		} else {
 			// Get specific packages for the model
 			filteredPackages = append(filteredPackages, KernelPackagesModels[s.Distro][ArchCommon][Model(config.DefaultConfig.Model)])

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -172,5 +172,5 @@ const (
 	AllSuseButMicroAndTumbleweed = "^(?:SLES.*|SUSE Linux Enterprise Server.*|[Oo]penSUSE Leap.*)$"
 	OnlyMicroRegex               = "SUSE Linux Enterprise Micro for Rancher.*"
 	AlpineRegex                  = "Alpine.*"
-	RHELFamilyRegex              = "Fedora.*|CentOS.*|Rocky.*|AlmaLinux.*|Red\\sHat.*"
+	RHELFamilyRegex              = "Fedora.*|CentOS.*|Rocky.*|AlmaLinux.*|Oracle\\sLinux.*|Red\\sHat.*"
 )

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -33,6 +33,7 @@ const (
 	RedHat             Distro = "rhel"
 	RockyLinux         Distro = "rocky"
 	AlmaLinux          Distro = "almalinux"
+	OracleLinux        Distro = "ol"
 	Fedora             Distro = "fedora"
 	Arch               Distro = "arch"
 	Alpine             Distro = "alpine"
@@ -165,7 +166,7 @@ func GetStepNames() []string {
 // AllSuseRegex matches any SUSE-based distribution name.
 // AllSuseButMicroRegex matches SLES, openSUSE, or SUSE Linux Enterprise Server names.
 // AlpineRegex matches Alpine Linux distribution names.
-// RHELFamilyRegex matches RHEL-family distributions such as Fedora, CentOS, Rocky, AlmaLinux, and Red Hat.
+// RHELFamilyRegex matches RHEL-family distributions such as Fedora, CentOS, Rocky, AlmaLinux, Oracle Linux, and Red Hat.
 const (
 	AllSuseRegex                 = "SLES.*|[Oo]penSUSE.*|SUSE.*"
 	AllSuseButMicroRegex         = "^(?:SLES.*|[Oo]penSUSE.*|SUSE Linux Enterprise Server.*)$"


### PR DESCRIPTION
Due to https://github.com/kairos-io/kairos/issues/3987
As of now, building an Oracle Linux based image will pass during kairos-init but skips the common RHEL Family steps