### PR TITLE
fix(grub): properly detach loop before trying to mount

### DIFF
--- a/pkg/bundled/bundled.go
+++ b/pkg/bundled/bundled.go
@@ -355,6 +355,7 @@ menuentry "${display_name}" --id cos {
   search --no-floppy --label --set=root COS_STATE
   set img=/cOS/active.img
   set label=COS_ACTIVE
+  loopback -d loop0
   loopback loop0 /$img
   set root=($root)
   source (loop0)/etc/cos/bootargs.cfg
@@ -366,6 +367,7 @@ menuentry "${display_name} (fallback)" --id fallback {
   search --no-floppy --label --set=root COS_STATE
   set img=/cOS/passive.img
   set label=COS_PASSIVE
+  loopback -d loop0
   loopback loop0 /$img
   set root=($root)
   source (loop0)/etc/cos/bootargs.cfg
@@ -382,6 +384,7 @@ menuentry "${display_name} recovery" --id recovery {
     set img=/cOS/recovery.img
   fi
   set label=COS_SYSTEM
+  loopback -d loop0
   loopback loop0 /$img
   set root=($root)
   source (loop0)/etc/cos/bootargs.cfg
@@ -398,6 +401,7 @@ menuentry "${display_name} state reset (auto)" --id statereset {
     set img=/cOS/recovery.img
   fi
   set label=COS_SYSTEM
+  loopback -d loop0
   loopback loop0 /$img
   set root=($root)
   source (loop0)/etc/cos/bootargs.cfg
@@ -528,6 +532,7 @@ const ExtraGrubCfg = `menuentry "${display_name} remote recovery" --id remoterec
         set img=/cOS/recovery.img
     fi
     set label=COS_SYSTEM
+    loopback -d loop0
     loopback loop0 /$img
     set root=($root)
     source (loop0)/etc/cos/bootargs.cfg


### PR DESCRIPTION
this fixes automatic fallback to entries on first boot if an image is broken after an upgrade.  The main change is the addition of a `loopback -d loop0` command before each use of the `loopback` command, ensuring that any previous `loop0` mappings are properly released before creating a new one. This helps prevent potential boot issues caused by stale loop device mappings when entires fails to boot.

video of the issue trying to upgrade to a broken image:

https://github.com/user-attachments/assets/de7525be-ff8a-4127-90c4-9533375837b0

Fix tested with:

```
FROM golang:1.26-alpine AS init-builder
RUN apk add --no-cache git make curl bash file
RUN git clone -b fix/grub-fallback https://github.com/kairos-io/kairos-init.git /src
WORKDIR /src
RUN SKIP_UPX=1 make download cleanup version-info
RUN CGO_ENABLED=0 go build -o /kairos-init .

FROM quay.io/kairos/hadron:v0.0.4-core-amd64-generic-v4.0.3
COPY --from=init-builder  /kairos-init  /usr/bin/kairos-init
ARG VERSION=1.0.0
RUN /usr/bin/kairos-init --version "${VERSION}"
RUN rm -rf /usr/bin/kairos-init
```
