### PR TITLE
Add Fedora and Hadron RISC-V test images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
             model: "generic"
             fips: false
           - platform: "riscv64"
-            base_image: "fedorariscv/base:latest"
+            base_image: "fedorariscv/fedora:41"
             model: "generic"
             fips: false
           - platform: "riscv64"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
             model: "generic"
             fips: false
           - platform: "riscv64"
-            base_image: "fedorariscv/fedora:41"
+            base_image: "fedorariscv/fedora:43"
             model: "generic"
             fips: false
           - platform: "riscv64"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,14 @@ jobs:
             base_image: "debian:13"
             model: "generic"
             fips: false
+          - platform: "riscv64"
+            base_image: "fedorariscv/base:latest"
+            model: "generic"
+            fips: false
+          - platform: "riscv64"
+            base_image: "ghcr.io/kairos-io/hadron:v0.1.1"
+            model: "generic"
+            fips: false
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
             model: "generic"
             fips: false
           - platform: "riscv64"
-            base_image: "ghcr.io/kairos-io/hadron:v0.1.1"
+            base_image: "ghcr.io/kairos-io/hadron:v0.2.0-beta.1"
             model: "generic"
             fips: false
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
             model: "generic"
             fips: false
           - platform: "riscv64"
-            base_image: "fedorariscv/fedora:43"
+            base_image: "fedorariscv/base:42"
             model: "generic"
             fips: false
           - platform: "riscv64"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,7 @@ builds:
     goarch:
       - amd64
       - arm64
+      - riscv64
     hooks:
       pre:
         - make


### PR DESCRIPTION
## Summary
- Add `fedorariscv/base:latest` to RISC-V CI test matrix
- Add `ghcr.io/kairos-io/hadron:v0.1.1` to RISC-V CI test matrix

## Test plan
- CI will run the new RISC-V builds automatically

Made with [Cursor](https://cursor.com)

Depends on https://github.com/kairos-io/hadron/pull/362