### PR TITLE
fix(install): try epel-release package first on RHEL, fall back to URL

### DIFF
--- a/pkg/stages/steps_install.go
+++ b/pkg/stages/steps_install.go
@@ -116,7 +116,10 @@ func GetInstallStage(sis values.System, logger logger.KairosLogger) ([]schema.St
 			Name:     "Install epel repository for Red Hat",
 			OnlyIfOs: "Red\\sHat.*",
 			Commands: []string{
-				fmt.Sprintf("dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-%d.noarch.rpm", fullVersion.Segments()[0]),
+				fmt.Sprintf(
+					"dnf install -y epel-release || dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-%d.noarch.rpm",
+					fullVersion.Segments()[0],
+				),
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

The Red Hat-specific EPEL setup stage in `pkg/stages/steps_install.go` (`GetInstallStage`) hardcodes a fetch from `https://dl.fedoraproject.org/pub/epel/epel-release-latest-N.noarch.rpm`. `dnf install -y URL` always reaches out to the URL first, so this breaks air-gapped or restricted-egress builders (Artifactory, Satellite, Spacewalk-style mirrors) that already configure an EPEL mirror locally but cannot reach `dl.fedoraproject.org`. UBI9 in particular triggers this branch because `PRETTY_NAME` matches `Red\sHat.*`.

This PR keeps the existing stage but tries the package install first and falls back to the URL if no EPEL repo is preconfigured:

```go
{
    Name:     "Install epel repository for Red Hat",
    OnlyIfOs: "Red\\sHat.*",
    Commands: []string{
        fmt.Sprintf(
            "dnf install -y epel-release || dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-%d.noarch.rpm",
            fullVersion.Segments()[0],
        ),
    },
},
```

## Why try-then-fallback instead of replacing outright

EPEL is community-run and `epel-release` is not shipped in any RHEL subscription repo or any UBI base repo. On a stock UBI/RHEL image with no extra repos, `dnf install epel-release` fails with "No match for argument", which is why the original code went straight to the upstream RPM URL. Replacing the URL path entirely (the first revision of this PR) was a behavior regression for the default build path. The fallback approach preserves the default behavior while letting air-gapped builders win first when they have an EPEL mirror configured locally.

## Behavior matrix

- AlmaLinux / Rocky / CentOS: untouched. Existing stage handles them via the `extras` repo's `epel-release`.
- Stock UBI / RHEL (no preconfigured EPEL repo): package install fails, URL fallback runs - identical to today.
- Air-gapped UBI / RHEL with a local EPEL repo file shipped before kairos-init: package install succeeds and honors the local mirror; URL is not reached.

## Test plan

- [x] `gofmt -l pkg/stages/steps_install.go` clean
- [x] `GOOS=linux GOARCH=amd64 go vet ./...` clean
- [x] `GOOS=linux GOARCH=amd64 go build ./...` clean
- [x] `GOOS=linux GOARCH=amd64 go test -c ./pkg/system ./pkg/validation` clean (cross-compiled darwin host can't exec linux test binaries; CI will run them)
- [ ] Maintainer to validate against UBI9 + AlmaLinux build matrices in CI

cc @kairos-io/maintainers