### PR TITLE
feat: Enhance NVIDIA board model handling

### DIFF
--- a/pkg/stages/steps_init.go
+++ b/pkg/stages/steps_init.go
@@ -1092,7 +1092,12 @@ func GetKairosInitramfsFilesStage(sis values.System, l logger.KairosLogger) ([]s
 			},
 			{
 				Name: "Disable ISCSI for NVIDIA devices",
-				If:   fmt.Sprintf(`[ "%[1]s" = "nvidia-jetson-agx-orin" ] || [ "%[1]s" = "nvidia-jetson-orin-nx" ]`, config.DefaultConfig.Model),
+				If: fmt.Sprintf(`[ "%[1]s" = "%s" ] || [ "%[1]s" = "%s" ] || [ "%[1]s" = "%s" ]`,
+					config.DefaultConfig.Model,
+					values.AgxOrin,
+					values.OrinNX,
+					values.Thor,
+				),
 				Files: []schema.File{
 					{
 						Path:        bundled.DracutSkipScsiPath,
@@ -1102,14 +1107,24 @@ func GetKairosInitramfsFilesStage(sis values.System, l logger.KairosLogger) ([]s
 						Content:     bundled.DracutSkipIscsi,
 					},
 				},
-				Commands: []string{
-					// iscsid causes delays on the login shell, and we don't need it, so we'll disable it
-					"systemctl disable iscsi open-iscsi iscsid.socket || true",
+				Systemctl: schema.Systemctl{
+					Disable: []string{
+						"iscsi",
+						"iscsid",
+						"open-iscsi",
+						"iscsiuio",
+					},
+					Mask: []string{
+						"iscsi",
+						"iscsid",
+						"open-iscsi",
+						"iscsiuio",
+					},
 				},
 			},
 			{
 				Name: "Omit nvidia drivers loading in the initramfs",
-				If:   fmt.Sprintf(`[ "%s" = "nvidia-jetson-thor" ]`, config.DefaultConfig.Model),
+				If:   fmt.Sprintf(`[ "%s" = "%s" ]`, config.DefaultConfig.Model, values.Thor),
 				Files: []schema.File{
 					{
 						Path:        bundled.DracutSkipNvidiaDriversPath,

--- a/pkg/stages/steps_install.go
+++ b/pkg/stages/steps_install.go
@@ -69,10 +69,19 @@ func GetInstallStage(sis values.System, logger logger.KairosLogger) ([]schema.St
 	l4tVersion := getEnvOrDefault("L4T_VERSION", "36.4")
 	// Get board model from environment or config
 	boardModel := getEnvOrDefault("BOARD_MODEL", "t234")
-	isNvidiaAgxOrOrinNxBoard := fmt.Sprintf(`[ "%[1]s" = "nvidia-jetson-agx-orin" ] || [ "%[1]s" = "nvidia-jetson-orin-nx" ]`, config.DefaultConfig.Model)
-	isNvidiaThorBoard := fmt.Sprintf(`[ "%s" = "nvidia-jetson-thor" ]`, config.DefaultConfig.Model)
+	isNvidiaAgxOrOrinNxBoard := fmt.Sprintf(`[ "%[1]s" = "%s" ] || [ "%[1]s" = "%s" ]`,
+		config.DefaultConfig.Model,
+		values.AgxOrin,
+		values.OrinNX,
+	)
+	isNvidiaThorBoard := fmt.Sprintf(`[ "%s" = "%s" ]`, config.DefaultConfig.Model, values.Thor)
 	// This matches any of the nvidia boards for steps shared between them
-	isNvidiaBoard := fmt.Sprintf(`[ "%[1]s" = "nvidia-jetson-agx-orin" ] || [ "%[1]s" = "nvidia-jetson-orin-nx" ] || [ "%[1]s" = "nvidia-jetson-thor" ]`, config.DefaultConfig.Model)
+	isNvidiaBoard := fmt.Sprintf(`[ "%[1]s" = "%s" ] || [ "%[1]s" = "%s" ] || [ "%[1]s" = "%s" ]`,
+		config.DefaultConfig.Model,
+		values.AgxOrin,
+		values.OrinNX,
+		values.Thor,
+	)
 
 	if values.Model(config.DefaultConfig.Model) == values.Thor {
 		logger.Logger.Info().Msg("NVIDIA Thor detected, using L4T version 38.4 for repository setup")

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -71,7 +71,7 @@ const (
 	Rpi4    Model = "rpi4"
 	AgxOrin Model = "nvidia-jetson-agx-orin"
 	OrinNX  Model = "nvidia-jetson-orin-nx"
-	Thor    Model = "nvidia-jetson-thor"
+	Thor    Model = "nvidia-jetson-agx-thor"
 )
 
 var SupportedModels = []Model{Generic, Rpi3, Rpi4, AgxOrin, OrinNX, Thor}


### PR DESCRIPTION
- Updated conditions to disable ISCSI for additional NVIDIA models: AgxOrin, OrinNX, and Thor.
- Modified initialization logic to correctly identify NVIDIA Thor as "nvidia-jetson-agx-thor".
- Improved clarity in model checks for better compatibility with various NVIDIA devices.