### PR TITLE
Potential fix for code scanning alert no. 36: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,6 @@ jobs:
   build:
     permissions:
       contents: read
-      packages: write
     needs:
       - build-linux-amd64
       - build-linux-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,13 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   goreleaser:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -79,6 +84,9 @@ jobs:
           push: true
           tags: ttl.sh/kairos:${{ github.sha }}-riscv64 # This are just temp images to build the final one
   build:
+    permissions:
+      contents: read
+      packages: write
     needs:
       - build-linux-amd64
       - build-linux-arm64


### PR DESCRIPTION
Potential fix for [https://github.com/kairos-io/kairos-init/security/code-scanning/36](https://github.com/kairos-io/kairos-init/security/code-scanning/36)

Add explicit `permissions` at the workflow level to enforce least privilege by default, then override on jobs that need elevated access.

Best approach here without changing functionality:
- Add a root-level `permissions` block with `contents: read` so all jobs default to read-only.
- Add a job-level `permissions` block for `goreleaser` with `contents: write` (release/tag publishing needs repository write access).
- Add a job-level `permissions` block for `build` with `packages: write` (publishing image manifests to container registry commonly needs package write scope).
- Keep all existing steps unchanged.

File/region to change:
- `.github/workflows/release.yml`
  - Insert workflow-level permissions after the `on:` block.
  - Insert job-level permissions under `goreleaser:`.
  - Insert job-level permissions under `build:`.

No imports/dependencies/methods are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
