### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - 'main'
 
+permissions:
+  contents: read
+  packages: write
+
 concurrency:
   group: build-main-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 concurrency:
   group: build-main-${{ github.head_ref || github.ref }}-${{ github.repository }}


### PR DESCRIPTION
Potential fix for [https://github.com/kairos-io/kairos-init/security/code-scanning/22](https://github.com/kairos-io/kairos-init/security/code-scanning/22)

Add an explicit `permissions` block at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, a safe minimal baseline is:

- `contents: read` (needed by `actions/checkout`)
- `packages: write` (needed for image push operations that may rely on token package permissions)

Even if some pushes here use external credentials, explicitly setting permissions documents intended access and prevents accidental privilege expansion if repo/org defaults change.

**File to edit:** `.github/workflows/docker.yml`  
**Change region:** immediately after `on:` block (before `concurrency:` is a clear location).

No imports, methods, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
