### PR TITLE
Bump provider-kairos to v2.15.1 and hadron to v0.2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
          - "oraclelinux:10"
          - "quay.io/centos/centos:stream9"
          - "quay.io/centos/centos:stream10"
-         - "ghcr.io/kairos-io/hadron:v0.0.1-beta6"
+         - "ghcr.io/kairos-io/hadron:v0.2.0"
          - "ghcr.io/kairos-io/hadron:main"
          - "registry.suse.com/suse/sle-micro-rancher/5.4:latest"
         include:
@@ -92,7 +92,7 @@ jobs:
             model: "generic"
             fips: false
           - platform: "riscv64"
-            base_image: "ghcr.io/kairos-io/hadron:v0.2.0-beta.1"
+            base_image: "ghcr.io/kairos-io/hadron:v0.2.0"
             model: "generic"
             fips: false
     steps:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 AGENT_VERSION := v2.29.0
 IMMUCORE_VERSION := v0.15.0
 KCRYPT_DISCOVERY_CHALLENGER_VERSION := v0.13.1
-PROVIDER_KAIROS_VERSION := v2.15.0
+PROVIDER_KAIROS_VERSION := v2.15.1
 EDGEVPN_VERSION := v0.32.2
 ARCH ?= $(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
 BINARY_NAMES := kairos-agent immucore kcrypt-discovery-challenger provider-kairos


### PR DESCRIPTION
## Summary
- Bump provider-kairos from v2.15.0 to v2.15.1
- Bump hadron test images from v0.0.1-beta6 and v0.2.0-beta.1 to v0.2.0

## Test plan
- CI tests will validate the updated dependencies


Made with [Cursor](https://cursor.com)