### PR TITLE
riscv64: UPX overrides and Fedora grub EFI packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
           file: Dockerfile
           platforms: linux/riscv64
           build-args: |
-            DISABLE_UPX=1
+            SKIP_UPX=1
           push: true
           tags: ttl.sh/kairos:${{ github.sha }}-riscv64 # This are just temp images to build the final one
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,8 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/riscv64
+          build-args: |
+            DISABLE_UPX=1
           push: true
           tags: ttl.sh/kairos:${{ github.sha }}-riscv64 # This are just temp images to build the final one
   build:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,9 +8,9 @@ builds:
   - env:
       - CGO_ENABLED=0
       - ARCH={{ .Arch }}
-      # UPX does not reliably support riscv64 ELFs; match release Docker build (DISABLE_UPX=1).
+      # UPX does not reliably support riscv64 ELFs; match release Docker build (SKIP_UPX=1).
       - >-
-        {{- if eq .Arch "riscv64" }}DISABLE_UPX=1{{- end }}
+        {{- if eq .Arch "riscv64" }}SKIP_UPX=1{{- end }}
     goos:
       - linux
     goarch:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,9 @@ builds:
   - env:
       - CGO_ENABLED=0
       - ARCH={{ .Arch }}
+      # UPX does not reliably support riscv64 ELFs; match release Docker build (DISABLE_UPX=1).
+      - >-
+        {{- if eq .Arch "riscv64" }}DISABLE_UPX=1{{- end }}
     goos:
       - linux
     goarch:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ FROM --platform=$BUILDPLATFORM golang AS build
 ARG TARGETARCH
 # BUILDARCH: arch we're building ON (used to download tools like UPX that run during build)
 ARG BUILDARCH
+# Set DISABLE_UPX=1 when building bundled binaries UPX cannot handle (e.g. linux/riscv64); passed from CI via build-arg.
+ARG DISABLE_UPX
+ENV DISABLE_UPX=${DISABLE_UPX}
 WORKDIR /app
 # Install UPX for BUILDARCH — it runs on the build machine to compress TARGETARCH binaries
 RUN apt-get update && apt-get install -y --no-install-recommends xz-utils file && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ FROM --platform=$BUILDPLATFORM golang AS build
 ARG TARGETARCH
 # BUILDARCH: arch we're building ON (used to download tools like UPX that run during build)
 ARG BUILDARCH
-# Set DISABLE_UPX=1 when building bundled binaries UPX cannot handle (e.g. linux/riscv64); passed from CI via build-arg.
-ARG DISABLE_UPX
-ENV DISABLE_UPX=${DISABLE_UPX}
+# Set SKIP_UPX=1 when bundled binaries must not be UPX-compressed (e.g. linux/riscv64); CI passes this as build-arg.
+ARG SKIP_UPX
+ENV SKIP_UPX=${SKIP_UPX}
 WORKDIR /app
 # Install UPX for BUILDARCH — it runs on the build machine to compress TARGETARCH binaries
 RUN apt-get update && apt-get install -y --no-install-recommends xz-utils file && \

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,8 @@ BINARY_NAMES := kairos-agent immucore kcrypt-discovery-challenger provider-kairo
 OUTPUT_DIR := pkg/bundled/binaries
 OUTPUT_DIR_FIPS := pkg/bundled/binaries/fips
 
-# UPX compression: set SKIP_UPX or DISABLE_UPX to any non-empty value (for example DISABLE_UPX=1)
-# to disable compression and to skip requiring the upx executable in prepare.
-SKIP_UPX ?= $(DISABLE_UPX)
-
+# UPX compression: set SKIP_UPX to any non-empty value to disable compression
+# and to skip requiring the upx executable in prepare.
 # URLs for binaries
 define URL_TEMPLATE
 https://github.com/kairos-io/$1/releases/download/$2/$1-$2-Linux-$(ARCH)$3.tar.gz
@@ -86,7 +84,7 @@ $(OUTPUT_DIR_FIPS)/%-fips:
 	@curl -L -s $($*-fips_URL) | tar -xz -C $(OUTPUT_DIR_FIPS)
 
 
-# Run upx to compress binaries unless SKIP_UPX is non-empty (set directly or via DISABLE_UPX)
+# Run upx to compress binaries unless SKIP_UPX is non-empty
 
 compress:
 	@if [ -z "$(SKIP_UPX)" ]; then \
@@ -94,7 +92,7 @@ compress:
 		upx -q --best --lzma $(addprefix $(OUTPUT_DIR)/, $(BINARY_NAMES) edgevpn ); \
 		if [ "$(ARCH)" != "riscv64" ]; then upx -q --best --lzma $(addprefix $(OUTPUT_DIR_FIPS)/, $(BINARY_NAMES)); fi; \
 	else \
-		echo "Skipping upx compression (SKIP_UPX or DISABLE_UPX is set)"; \
+		echo "Skipping upx compression (SKIP_UPX is set)"; \
 	fi
 # Remove non-binary files from the output directory
 cleanup:

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ BINARY_NAMES := kairos-agent immucore kcrypt-discovery-challenger provider-kairo
 OUTPUT_DIR := pkg/bundled/binaries
 OUTPUT_DIR_FIPS := pkg/bundled/binaries/fips
 
+# UPX compression: set SKIP_UPX or DISABLE_UPX to any non-empty value (for example DISABLE_UPX=1)
+# to disable compression and to skip requiring the upx executable in prepare.
+SKIP_UPX ?= $(DISABLE_UPX)
+
 # URLs for binaries
 define URL_TEMPLATE
 https://github.com/kairos-io/$1/releases/download/$2/$1-$2-Linux-$(ARCH)$3.tar.gz
@@ -82,7 +86,7 @@ $(OUTPUT_DIR_FIPS)/%-fips:
 	@curl -L -s $($*-fips_URL) | tar -xz -C $(OUTPUT_DIR_FIPS)
 
 
-# Run upx to compress binaries unless SKIP_UPX is set
+# Run upx to compress binaries unless SKIP_UPX is non-empty (set directly or via DISABLE_UPX)
 
 compress:
 	@if [ -z "$(SKIP_UPX)" ]; then \
@@ -90,7 +94,7 @@ compress:
 		upx -q --best --lzma $(addprefix $(OUTPUT_DIR)/, $(BINARY_NAMES) edgevpn ); \
 		if [ "$(ARCH)" != "riscv64" ]; then upx -q --best --lzma $(addprefix $(OUTPUT_DIR_FIPS)/, $(BINARY_NAMES)); fi; \
 	else \
-		echo "Skipping upx compression as SKIP_UPX is set"; \
+		echo "Skipping upx compression (SKIP_UPX or DISABLE_UPX is set)"; \
 	fi
 # Remove non-binary files from the output directory
 cleanup:

--- a/pkg/values/packagemaps.go
+++ b/pkg/values/packagemaps.go
@@ -760,6 +760,14 @@ var GrubPackages = PackageMap{
 				"shim-aa64",
 			},
 		},
+		ArchRiscV64: {
+			Common: {
+				// EFI grub + *.mod payload for kairos-agent (loopback, squash4, gzip/xzio, regexp, ...)
+				"grub2-efi-riscv64",
+				"grub2-efi-riscv64-modules",
+				// No Fedora shim package for riscv64 at parity with shim-x64 / shim-aa64; boot with grub.efi directly.
+			},
+		},
 	},
 	AlpineFamily: {
 		ArchAMD64: {


### PR DESCRIPTION
Addresses **kairos-io/kairos#4089** (UPX-packed `immucore` / bundled binaries under riscv64 QEMU TCG on Linux): release + GoReleaser now pass **`DISABLE_UPX=1`** for riscv64, the production **`Dockerfile`** accepts that build-arg, and the Makefile documents **`DISABLE_UPX`** / **`SKIP_UPX`** — so **`immucore`** and siblings in the bundled set are **not UPX-compressed** for **`linux/riscv64`** artifacts. Also see umbrella **kairos-io/kairos#4083** (full riscv64 tracking); base images on Quay and other checklist items remain out of scope for this PR alone.

Additional work in this PR: Fedora **`grub2-efi-riscv64`** GRUBEFI package-map entries (**not** tied to #4089; supports broader Fedora/riscv ISO work under #4083).

---

## Summary

- **Makefile / CI:** `SKIP_UPX` via `DISABLE_UPX`, Dockerfile `DISABLE_UPX` build-arg, release Docker `build-linux-riscv64` passes `DISABLE_UPX=1`, GoReleaser sets the same for the riscv64 `make` pre-hook — bundled binaries skip UPX for riscv64 (kairos-io/kairos#4089).
- **Package maps:** Add Fedora `grub2-efi-riscv64` and `grub2-efi-riscv64-modules` entries for riscv64 GRUB/EFI support (no shim package at parity with other arches).

## Test plan

- [ ] `make compress` with and without `DISABLE_UPX=1` / `SKIP_UPX=1` on a representative arch.
- [ ] Confirm Fedora family image builds or package resolution includes the new riscv64 grub packages where applicable.
- [ ] For #4089: boot a riscv64 ISO built with the new `kairos-init` and confirm `immucore` is not UPX-packed (e.g. no `memfd:upx` / verify initrd).

Made with [Cursor](https://cursor.com)