### PR TITLE
feat: Enable VMware tools for systemd and OpenRC

### DIFF
--- a/pkg/bundled/cloudconfigs/26_vm.yaml
+++ b/pkg/bundled/cloudconfigs/26_vm.yaml
@@ -25,3 +25,15 @@ stages:
       only_service_manager: "systemd"
       commands:
         - systemctl start vmtoolsd
+    - name: "Enable VMWARE"
+      if: |
+        grep -iE "VMware" /sys/class/dmi/id/product_name
+      only_service_manager: "openrc"
+      commands:
+        - rc-service open-vm-tools start
+    - name: "Enable VMWARE"
+      if: |
+        grep -iE "VMware" /sys/class/dmi/id/product_name
+      only_service_manager: "systemd"
+      commands:
+        - systemctl start vmtoolsd


### PR DESCRIPTION
- Added configuration to start VMware tools service for both systemd and OpenRC
- Ensures compatibility with VMware environments by checking for VMware product name

Part of https://github.com/kairos-io/kairos/issues/4092