### PR TITLE
fix: Update model detection for Thor

### DIFF
--- a/pkg/bundled/bundled.go
+++ b/pkg/bundled/bundled.go
@@ -464,7 +464,7 @@ function setExtraConsole {
 		echo "Found orin-nx model"
         set baseExtraConsole="console=ttyTCU0,115200 console=ttyAMA0,115200"
     fi
-    if test -n "$model" -a "$model" == "Thor"; then
+    if test $KAIROS_MODEL == "nvidia-jetson-thor"; then
 		echo "Found Thor model, setting console options"
 		set baseExtraConsole="console=ttyUTC0,115200 earlycon=tegra_utc,mmio32,0xc5a0000"
 	fi
@@ -481,7 +481,7 @@ function setExtraArgs {
         # on rpi we need to enable memory cgroup for docker/k3s to work
         set baseExtraArgs="modprobe.blacklist=vc4 8250.nr_uarts=1 cgroup_enable=memory"
     fi
-    if test -n "$model" -a "$model" == "Thor"; then
+    if test $KAIROS_MODEL == "nvidia-jetson-thor"; then
 		echo "Found Thor model, setting ignore unused options"
 		# on Thor we need to set the ignore unused so devices don't die during booting
 		set baseExtraArgs="pd_ignore_unused clk_ignore_unused fbcon=map:0 nospectre_bhb efi=runtime"
@@ -503,9 +503,6 @@ function setKernelCmd {
         set baseRootCmd="root=LABEL=$label cos-img/filename=$img"
     fi
     setSelinux
-    # load smbios module and detect model once, reused by setExtraConsole and setExtraArgs
-    insmod smbios
-    smbios --type 4 --get-string 5 --set model
     setExtraConsole
     setExtraArgs
     # finally set the full cmdline


### PR DESCRIPTION
- Changed model detection condition from checking `$model` to `$KAIROS_MODEL` for the Thor model.
- This ensures accurate identification of the Thor model as `nvidia-jetson-thor` for proper console and boot options.

This is what happens when you think you are more intelligent than the world and expect everyone to ship the smbios module for grub :D

Lets jsut use the expected KAIROS_MODEL which we use already for other boards with success