### PR TITLE
feat: place default kairos-installer at /system/installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ AGENT_VERSION := v2.29.4
 KCRYPT_DISCOVERY_CHALLENGER_VERSION := v0.13.2
 PROVIDER_KAIROS_VERSION := v2.16.1
 EDGEVPN_VERSION := v0.35.2
+INSTALLER_VERSION := v0.1.0
 ARCH ?= $(shell uname -m | sed -e 's/x86_64/amd64/' -e 's/aarch64/arm64/')
 BINARY_NAMES := kairos-agent immucore kcrypt-discovery-challenger provider-kairos
 OUTPUT_DIR := pkg/bundled/binaries
@@ -59,7 +60,7 @@ else
 FIPS_BINARIES := $(addprefix $(OUTPUT_DIR_FIPS)/, $(addsuffix -fips, $(BINARY_NAMES)))
 endif
 
-download: $(addprefix $(OUTPUT_DIR)/, $(BINARY_NAMES)) $(FIPS_BINARIES) download-edgevpn
+download: $(addprefix $(OUTPUT_DIR)/, $(BINARY_NAMES)) $(FIPS_BINARIES) download-edgevpn download-kairos-installer
 ifeq ($(ARCH),riscv64)
 	@echo "Skipping FIPS binaries download for riscv64."
 endif
@@ -70,6 +71,12 @@ download-edgevpn:
 	@mkdir -p $(OUTPUT_DIR)
 	@# Unfortunately edgevpn uses x86_64 instead of amd64 so we need to do some string manipulation here
 	@curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 https://github.com/mudler/edgevpn/releases/download/$(EDGEVPN_VERSION)/edgevpn-$(EDGEVPN_VERSION)-Linux-$(shell echo $(ARCH) | sed -e 's/amd64/x86_64/').tar.gz | tar -xz -C $(OUTPUT_DIR)
+
+# Download kairos-installer (no FIPS variant; same binary for all image flavors)
+download-kairos-installer:
+	@echo "Downloading and extracting kairos-installer for architecture $(ARCH)..."
+	@mkdir -p $(OUTPUT_DIR)
+	@curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 https://github.com/kairos-io/kairos-installer/releases/download/$(INSTALLER_VERSION)/kairos-installer-$(INSTALLER_VERSION)-Linux-$(ARCH).tar.gz | tar -xz -C $(OUTPUT_DIR)
 
 # Download each binary
 $(OUTPUT_DIR)/%:
@@ -89,7 +96,7 @@ $(OUTPUT_DIR_FIPS)/%-fips:
 compress:
 	@if [ -z "$(SKIP_UPX)" ]; then \
 		echo "Running upx compress..."; \
-		upx -q --best --lzma $(addprefix $(OUTPUT_DIR)/, $(BINARY_NAMES) edgevpn ); \
+		upx -q --best --lzma $(addprefix $(OUTPUT_DIR)/, $(BINARY_NAMES) edgevpn kairos-installer ); \
 		if [ "$(ARCH)" != "riscv64" ]; then upx -q --best --lzma $(addprefix $(OUTPUT_DIR_FIPS)/, $(BINARY_NAMES)); fi; \
 	else \
 		echo "Skipping upx compression (SKIP_UPX is set)"; \

--- a/pkg/bundled/bundled.go
+++ b/pkg/bundled/bundled.go
@@ -17,6 +17,9 @@ var EmbeddedKcryptChallenger []byte
 //go:embed binaries/provider-kairos
 var EmbeddedKairosProvider []byte
 
+//go:embed binaries/kairos-installer
+var EmbeddedKairosInstaller []byte
+
 //nolint:staticcheck
 //go:embed binaries/edgevpn
 var EmbeddedEdgeVPN []byte

--- a/pkg/stages/steps_install.go
+++ b/pkg/stages/steps_install.go
@@ -426,6 +426,19 @@ func GetInstallGrubBootArgsStage(_ values.System, l logger.KairosLogger) []schem
 	return data
 }
 
+// installKairosInstaller places the default (embedded) kairos-installer at
+// /system/installer/kairos-installer. kairos-init does not download it at
+// install time — the binary is bundled into the image at build time, so the
+// image can be built offline like every other bundled binary.
+func installKairosInstaller(l logger.KairosLogger) error {
+	dest := "/system/installer/kairos-installer"
+	if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+		l.Logger.Error().Err(err).Str("dir", filepath.Dir(dest)).Msg("Failed to create directory")
+		return err
+	}
+	return os.WriteFile(dest, bundled.EmbeddedKairosInstaller, 0755)
+}
+
 // GetInstallKairosBinaries directly installs the kairos binaries from bundled binaries
 func GetInstallKairosBinaries(sis values.System, l logger.KairosLogger) error {
 	if config.ContainsSkipStep(values.KairosBinariesStep) {
@@ -490,6 +503,11 @@ func GetInstallKairosBinaries(sis values.System, l logger.KairosLogger) error {
 				return err
 			}
 		}
+	}
+
+	if err := installKairosInstaller(l); err != nil {
+		l.Logger.Error().Err(err).Msg("Failed to install kairos-installer")
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Places the default kairos-installer binary in built images at /system/installer/kairos-installer so kairos-agent interactive-install resolves it. Part of extracting the interactive installer into the standalone kairos-installer binary.

- VersionOverrides.KairosInstaller (kairos_installer yaml key) for an optional online version override.
- GetInstallKairosBinaries places /system/installer/kairos-installer, always the non-FIPS asset/embed (kairos-installer has no FIPS build; same binary in FIPS and non-FIPS images).
- Embeds the v0.1.0 release via a download-kairos-installer Make target (edgevpn-style, all arches incl. riscv64).